### PR TITLE
Add AWS session information labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,80 +32,80 @@ It collect key metrics about:
 
 ## Metrics
 
-| Name | Description |
-| ------ | ----------- |
-| rds_allocated_storage_bytes | Allocated storage |
-| rds_api_call_total | Number of call to AWS API |
-| rds_backup_retention_period_seconds | Automatic DB snapshots retention period |
-| rds_cpu_usage_percent_average | Instance CPU used |
-| rds_database_connections_average | The number of client network connections to the database instance |
-| rds_dbload_average | Number of active sessions for the DB engine |
-| rds_dbload_cpu_average | Number of active sessions where the wait event type is CPU |
-| rds_dbload_noncpu_average | Number of active sessions where the wait event type is not CPU |
-| rds_exporter_build_info | A metric with constant '1' value labeled by version from which exporter was built |
-| rds_exporter_errors_total | Total number of errors encountered by the exporter |
-| rds_free_storage_bytes | Free storage on the instance |
-| rds_freeable_memory_bytes | Amount of available random access memory. For MariaDB, MySQL, Oracle, and PostgreSQL DB instances, this metric reports the value of the MemAvailable field of /proc/meminfo |
-| rds_instance_info | RDS instance information |
-| rds_instance_log_files_size_bytes | Total of log files on the instance |
-| rds_instance_maxIops_average | Maximum IOPS of underlying EC2 instance |
-| rds_instance_max_throughput_bytes | Maximum throughput of underlying EC2 instance |
-| rds_instance_memory_bytes | Instance memory |
-| rds_instance_status | Instance status (1: ok, 0: can't scrap metrics) |
-| rds_instance_vcpu_average | Total vCPU for this isntance class |
-| rds_max_allocated_storage_bytes | Upper limit in gibibytes to which Amazon RDS can automatically scale the storage of the DB instance |
-| rds_max_disk_iops_average | Max IOPS for the instance |
-| rds_max_storage_throughput_bytes | Max storage throughput |
-| rds_maximum_used_transaction_ids_average | Maximum transaction IDs that have been used. Applies to only PostgreSQL |
-| rds_quota_max_dbinstances_average | Maximum number of RDS instances allowed in the AWS account |
-| rds_quota_maximum_db_instance_snapshots_average | Maximum number of manual DB instance snapshots |
-| rds_quota_total_storage_bytes | Maximum total storage for all DB instances |
-| rds_read_iops_average | Average number of disk read I/O operations per second |
-| rds_read_throughput_bytes | Average number of bytes read from disk per second |
-| rds_replica_lag_seconds | For read replica configurations, the amount of time a read replica DB instance lags behind the source DB instance. Applies to MariaDB, Microsoft SQL Server, MySQL, Oracle, and PostgreSQL read replicas |
-| rds_replication_slot_disk_usage_average | Disk space used by replication slot files. Applies to PostgreSQL |
-| rds_swap_usage_bytes | Amount of swap space used on the DB instance. This metric is not available for SQL Server |
-| rds_usage_allocated_storage_average | Total storage used by AWS RDS instances |
-| rds_usage_db_instances_average | AWS RDS instance count |
-| rds_usage_manual_snapshots_average | Manual snapshots count |
-| rds_write_iops_average | Average number of disk write I/O operations per second |
-| rds_write_throughput_bytes | Average number of bytes written to disk per second |
-| up | Was the last scrape of RDS successful |
+| Name | Labels | Description |
+| ---- | ------ | ----------- |
+| rds_allocated_storage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Allocated storage |
+| rds_api_call_total | `api`, `aws_account_id`, `aws_region` | Number of call to AWS API |
+| rds_backup_retention_period_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | Automatic DB snapshots retention period |
+| rds_cpu_usage_percent_average | `aws_account_id`, `aws_region`, `dbidentifier` | Instance CPU used |
+| rds_database_connections_average | `aws_account_id`, `aws_region`, `dbidentifier` | The number of client network connections to the database instance |
+| rds_dbload_average | `aws_account_id`, `aws_region`, `dbidentifier` | Number of active sessions for the DB engine |
+| rds_dbload_cpu_average | `aws_account_id`, `aws_region`, `dbidentifier` | Number of active sessions where the wait event type is CPU |
+| rds_dbload_noncpu_average | `aws_account_id`, `aws_region`, `dbidentifier` | Number of active sessions where the wait event type is not CPU |
+| rds_exporter_build_info | `build_date`, `commit_sha`, `version` | A metric with constant '1' value labeled by version from which exporter was built |
+| rds_exporter_errors_total | | Total number of errors encountered by the exporter |
+| rds_free_storage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Free storage on the instance |
+| rds_freeable_memory_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of available random access memory. For MariaDB, MySQL, Oracle, and PostgreSQL DB instances, this metric reports the value of the MemAvailable field of /proc/meminfo |
+| rds_instance_info | `aws_account_id`, `aws_region`, `dbi_resource_id`, `dbidentifier`, `deletion_protection`, `engine`, `engine_version`, `instance_class`, `multi_az`, `pending_maintenance`, `pending_modified_values`, `role`, `source_dbidentifier`, `storage_type` | RDS instance information |
+| rds_instance_log_files_size_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Total of log files on the instance |
+| rds_instance_maxIops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum IOPS of underlying EC2 instance |
+| rds_instance_max_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum throughput of underlying EC2 instance |
+| rds_instance_memory_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Instance memory |
+| rds_instance_status | `aws_account_id`, `aws_region`, `dbidentifier` | Instance status (1: ok, 0: can't scrap metrics) |
+| rds_instance_vcpu_average | `aws_account_id`, `aws_region`, `dbidentifier` | Total vCPU for this isntance class |
+| rds_max_allocated_storage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Upper limit in gibibytes to which Amazon RDS can automatically scale the storage of the DB instance |
+| rds_max_disk_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Max IOPS for the instance |
+| rds_max_storage_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Max storage throughput |
+| rds_maximum_used_transaction_ids_average | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum transaction IDs that have been used. Applies to only PostgreSQL |
+| rds_quota_max_dbinstances_average | `aws_account_id`, `aws_region` | Maximum number of RDS instances allowed in the AWS account |
+| rds_quota_maximum_db_instance_snapshots_average | `aws_account_id`, `aws_region` | Maximum number of manual DB instance snapshots |
+| rds_quota_total_storage_bytes | `aws_account_id`, `aws_region` | Maximum total storage for all DB instances |
+| rds_read_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of disk read I/O operations per second |
+| rds_read_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of bytes read from disk per second |
+| rds_replica_lag_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | For read replica configurations, the amount of time a read replica DB instance lags behind the source DB instance. Applies to MariaDB, Microsoft SQL Server, MySQL, Oracle, and PostgreSQL read replicas |
+| rds_replication_slot_disk_usage_average | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by replication slot files. Applies to PostgreSQL |
+| rds_swap_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of swap space used on the DB instance. This metric is not available for SQL Server |
+| rds_usage_allocated_storage_average | `aws_account_id`, `aws_region` | Total storage used by AWS RDS instances |
+| rds_usage_db_instances_average | `aws_account_id`, `aws_region` | AWS RDS instance count |
+| rds_usage_manual_snapshots_average | `aws_account_id`, `aws_region` | Manual snapshots count |
+| rds_write_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of disk write I/O operations per second |
+| rds_write_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of bytes written to disk per second |
+| up | | Was the last scrape of RDS successful |
 
 <details>
   <summary>Standard Go and Prometheus metrics are also available</summary>
 
-| Name | Description |
-| ------ | ----------- |
-| go_gc_duration_seconds | A summary of the pause duration of garbage collection cycles. |
-| go_goroutines | Number of goroutines that currently exist. |
-| go_info | Information about the Go environment. |
-| go_memstats_alloc_bytes | Number of bytes allocated and still in use. |
-| go_memstats_alloc_bytes_total | Total number of bytes allocated, even if freed. |
-| go_memstats_buck_hash_sys_bytes | Number of bytes used by the profiling bucket hash table. |
-| go_memstats_frees_total | Total number of frees. |
-| go_memstats_gc_sys_bytes | Number of bytes used for garbage collection system metadata. |
-| go_memstats_heap_alloc_bytes | Number of heap bytes allocated and still in use. |
-| go_memstats_heap_idle_bytes | Number of heap bytes waiting to be used. |
-| go_memstats_heap_inuse_bytes | Number of heap bytes that are in use. |
-| go_memstats_heap_objects | Number of allocated objects. |
-| go_memstats_heap_released_bytes | Number of heap bytes released to OS. |
-| go_memstats_heap_sys_bytes | Number of heap bytes obtained from system. |
-| go_memstats_last_gc_time_seconds | Number of seconds since 1970 of last garbage collection. |
-| go_memstats_lookups_total | Total number of pointer lookups. |
-| go_memstats_mallocs_total | Total number of mallocs. |
-| go_memstats_mcache_inuse_bytes | Number of bytes in use by mcache structures. |
-| go_memstats_mcache_sys_bytes | Number of bytes used for mcache structures obtained from system. |
-| go_memstats_mspan_inuse_bytes | Number of bytes in use by mspan structures. |
-| go_memstats_mspan_sys_bytes | Number of bytes used for mspan structures obtained from system. |
-| go_memstats_next_gc_bytes | Number of heap bytes when next garbage collection will take place. |
-| go_memstats_other_sys_bytes | Number of bytes used for other system allocations. |
-| go_memstats_stack_inuse_bytes | Number of bytes in use by the stack allocator. |
-| go_memstats_stack_sys_bytes | Number of bytes obtained from system for stack allocator. |
-| go_memstats_sys_bytes | Number of bytes obtained from system. |
-| go_threads | Number of OS threads created. |
-| promhttp_metric_handler_requests_in_flight | Current number of scrapes being served. |
-| promhttp_metric_handler_requests_total | Total number of scrapes by HTTP status code. |
+| Name   | Labels | Description |
+| ------ | -------| ----------- |
+| go_gc_duration_seconds | `quantile` | A summary of the pause duration of garbage collection cycles. |
+| go_goroutines | | Number of goroutines that currently exist. |
+| go_info | `version` | Information about the Go environment. |
+| go_memstats_alloc_bytes | | Number of bytes allocated and still in use. |
+| go_memstats_alloc_bytes_total | | Total number of bytes allocated, even if freed. |
+| go_memstats_buck_hash_sys_bytes | | Number of bytes used by the profiling bucket hash table. |
+| go_memstats_frees_total | | Total number of frees. |
+| go_memstats_gc_sys_bytes | | Number of bytes used for garbage collection system metadata. |
+| go_memstats_heap_alloc_bytes | | Number of heap bytes allocated and still in use. |
+| go_memstats_heap_idle_bytes | | Number of heap bytes waiting to be used. |
+| go_memstats_heap_inuse_bytes | | Number of heap bytes that are in use. |
+| go_memstats_heap_objects | | Number of allocated objects. |
+| go_memstats_heap_released_bytes | | Number of heap bytes released to OS. |
+| go_memstats_heap_sys_bytes | | Number of heap bytes obtained from system. |
+| go_memstats_last_gc_time_seconds | | Number of seconds since 1970 of last garbage collection. |
+| go_memstats_lookups_total | | Total number of pointer lookups. |
+| go_memstats_mallocs_total | | Total number of mallocs. |
+| go_memstats_mcache_inuse_bytes | | Number of bytes in use by mcache structures. |
+| go_memstats_mcache_sys_bytes | | Number of bytes used for mcache structures obtained from system. |
+| go_memstats_mspan_inuse_bytes | | Number of bytes in use by mspan structures. |
+| go_memstats_mspan_sys_bytes | | Number of bytes used for mspan structures obtained from system. |
+| go_memstats_next_gc_bytes | | Number of heap bytes when next garbage collection will take place. |
+| go_memstats_other_sys_bytes | | Number of bytes used for other system allocations. |
+| go_memstats_stack_inuse_bytes | | Number of bytes in use by the stack allocator. |
+| go_memstats_stack_sys_bytes | | Number of bytes obtained from system for stack allocator. |
+| go_memstats_sys_bytes | | Number of bytes obtained from system. |
+| go_threads | | Number of OS threads created. |
+| promhttp_metric_handler_requests_in_flight | | Current number of scrapes being served. |
+| promhttp_metric_handler_requests_total | `code` | Total number of scrapes by HTTP status code. |
 
 </details>
 

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -29,3 +29,14 @@ func getAWSConfiguration(logger *slog.Logger, roleArn string, sessionName string
 
 	return cfg, nil
 }
+
+func getAWSSessionInformation(cfg aws.Config) (string, string, error) {
+	client := sts.NewFromConfig(cfg)
+
+	output, err := client.GetCallerIdentity(context.TODO(), nil)
+	if err != nil {
+		return "", "", fmt.Errorf("can't fetch information about current session: %w", err)
+	}
+
+	return cfg.Region, *output.Account, nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,11 +50,18 @@ func run(configuration exporterConfig) {
 		os.Exit(awsErrorExitCode)
 	}
 
+	awsAccountID, awsRegion, err := getAWSSessionInformation(cfg)
+	if err != nil {
+		logger.Error("can't identify AWS account and/or region", "reason", err)
+		os.Exit(awsErrorExitCode)
+	}
+
 	rdsClient := rds.NewFromConfig(cfg)
 	ec2Client := ec2.NewFromConfig(cfg)
 	cloudWatchClient := cloudwatch.NewFromConfig(cfg)
 	servicequotasClient := servicequotas.NewFromConfig(cfg)
-	collector := exporter.NewCollector(*logger, rdsClient, ec2Client, cloudWatchClient, servicequotasClient)
+
+	collector := exporter.NewCollector(*logger, awsAccountID, awsRegion, rdsClient, ec2Client, cloudWatchClient, servicequotasClient)
 
 	prometheus.MustRegister(collector)
 

--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -38,10 +38,12 @@ type metrics struct {
 }
 
 type rdsCollector struct {
-	wg       sync.WaitGroup
-	logger   slog.Logger
-	counters counters
-	metrics  metrics
+	wg           sync.WaitGroup
+	logger       slog.Logger
+	counters     counters
+	metrics      metrics
+	awsAccountID string
+	awsRegion    string
 
 	rdsClient           rdsClient
 	EC2Client           EC2Client
@@ -87,9 +89,11 @@ type rdsCollector struct {
 	exporterBuildInformation    *prometheus.Desc
 }
 
-func NewCollector(logger slog.Logger, rdsClient rdsClient, ec2Client EC2Client, cloudWatchClient cloudWatchClient, servicequotasClient servicequotasClient) *rdsCollector {
+func NewCollector(logger slog.Logger, awsAccountID string, awsRegion string, rdsClient rdsClient, ec2Client EC2Client, cloudWatchClient cloudWatchClient, servicequotasClient servicequotasClient) *rdsCollector {
 	return &rdsCollector{
 		logger:              logger,
+		awsAccountID:        awsAccountID,
+		awsRegion:           awsRegion,
 		rdsClient:           rdsClient,
 		servicequotasClient: servicequotasClient,
 		EC2Client:           ec2Client,
@@ -105,67 +109,67 @@ func NewCollector(logger slog.Logger, rdsClient rdsClient, ec2Client EC2Client, 
 		),
 		allocatedStorage: prometheus.NewDesc("rds_allocated_storage_bytes",
 			"Allocated storage",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		information: prometheus.NewDesc("rds_instance_info",
 			"RDS instance information",
-			[]string{"dbidentifier", "dbi_resource_id", "instance_class", "engine", "engine_version", "storage_type", "multi_az", "deletion_protection", "role", "source_dbidentifier", "pending_modified_values", "pending_maintenance"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier", "dbi_resource_id", "instance_class", "engine", "engine_version", "storage_type", "multi_az", "deletion_protection", "role", "source_dbidentifier", "pending_modified_values", "pending_maintenance"}, nil,
 		),
 		maxAllocatedStorage: prometheus.NewDesc("rds_max_allocated_storage_bytes",
 			"Upper limit in gibibytes to which Amazon RDS can automatically scale the storage of the DB instance",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		maxIops: prometheus.NewDesc("rds_max_disk_iops_average",
 			"Max IOPS for the instance",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		storageThroughput: prometheus.NewDesc("rds_max_storage_throughput_bytes",
 			"Max storage throughput",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		readThroughput: prometheus.NewDesc("rds_read_throughput_bytes",
 			"Average number of bytes read from disk per second",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		writeThroughput: prometheus.NewDesc("rds_write_throughput_bytes",
 			"Average number of bytes written to disk per second",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		status: prometheus.NewDesc("rds_instance_status",
 			fmt.Sprintf("Instance status (%d: ok, %d: can't scrap metrics)", int(exporterUpStatusCode), int(exporterDownStatusCode)),
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		logFilesSize: prometheus.NewDesc("rds_instance_log_files_size_bytes",
 			"Total of log files on the instance",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		instanceVCPU: prometheus.NewDesc("rds_instance_vcpu_average",
 			"Total vCPU for this isntance class",
-			[]string{"instance_class"}, nil,
+			[]string{"aws_account_id", "aws_region", "instance_class"}, nil,
 		),
 		instanceMemory: prometheus.NewDesc("rds_instance_memory_bytes",
 			"Instance memory",
-			[]string{"instance_class"}, nil,
+			[]string{"aws_account_id", "aws_region", "instance_class"}, nil,
 		),
 		cpuUtilisation: prometheus.NewDesc("rds_cpu_usage_percent_average",
 			"Instance CPU used",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		instanceMaximumThroughput: prometheus.NewDesc("rds_instance_max_throughput_bytes",
 			"Maximum throughput of underlying EC2 instance",
-			[]string{"instance_class"}, nil,
+			[]string{"aws_account_id", "aws_region", "instance_class"}, nil,
 		),
 		instanceMaximumIops: prometheus.NewDesc("rds_instance_maxIops_average",
 			"Maximum IOPS of underlying EC2 instance",
-			[]string{"instance_class"}, nil,
+			[]string{"aws_account_id", "aws_region", "instance_class"}, nil,
 		),
 		freeStorageSpace: prometheus.NewDesc("rds_free_storage_bytes",
 			"Free storage on the instance",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		databaseConnections: prometheus.NewDesc("rds_database_connections_average",
 			"The number of client network connections to the database instance",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		up: prometheus.NewDesc("up",
 			"Was the last scrape of RDS successful",
@@ -173,75 +177,75 @@ func NewCollector(logger slog.Logger, rdsClient rdsClient, ec2Client EC2Client, 
 		),
 		swapUsage: prometheus.NewDesc("rds_swap_usage_bytes",
 			"Amount of swap space used on the DB instance. This metric is not available for SQL Server",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		writeIOPS: prometheus.NewDesc("rds_write_iops_average",
 			"Average number of disk write I/O operations per second",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		readIOPS: prometheus.NewDesc("rds_read_iops_average",
 			"Average number of disk read I/O operations per second",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		replicaLag: prometheus.NewDesc("rds_replica_lag_seconds",
 			"For read replica configurations, the amount of time a read replica DB instance lags behind the source DB instance. Applies to MariaDB, Microsoft SQL Server, MySQL, Oracle, and PostgreSQL read replicas",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		replicationSlotDiskUsage: prometheus.NewDesc("rds_replication_slot_disk_usage_average",
 			"Disk space used by replication slot files. Applies to PostgreSQL",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		maximumUsedTransactionIDs: prometheus.NewDesc("rds_maximum_used_transaction_ids_average",
 			"Maximum transaction IDs that have been used. Applies to only PostgreSQL",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		freeableMemory: prometheus.NewDesc("rds_freeable_memory_bytes",
 			"Amount of available random access memory. For MariaDB, MySQL, Oracle, and PostgreSQL DB instances, this metric reports the value of the MemAvailable field of /proc/meminfo",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		apiCall: prometheus.NewDesc("rds_api_call_total",
 			"Number of call to AWS API",
-			[]string{"api"}, nil,
+			[]string{"aws_account_id", "aws_region", "api"}, nil,
 		),
 		backupRetentionPeriod: prometheus.NewDesc("rds_backup_retention_period_seconds",
 			"Automatic DB snapshots retention period",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		DBLoad: prometheus.NewDesc("rds_dbload_average",
 			"Number of active sessions for the DB engine",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		dBLoadCPU: prometheus.NewDesc("rds_dbload_cpu_average",
 			"Number of active sessions where the wait event type is CPU",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		dBLoadNonCPU: prometheus.NewDesc("rds_dbload_noncpu_average",
 			"Number of active sessions where the wait event type is not CPU",
-			[]string{"dbidentifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		quotaDBInstances: prometheus.NewDesc("rds_quota_max_dbinstances_average",
 			"Maximum number of RDS instances allowed in the AWS account",
-			nil, nil,
+			[]string{"aws_account_id", "aws_region"}, nil,
 		),
 		quotaTotalStorage: prometheus.NewDesc("rds_quota_total_storage_bytes",
 			"Maximum total storage for all DB instances",
-			nil, nil,
+			[]string{"aws_account_id", "aws_region"}, nil,
 		),
 		quotaMaxDBInstanceSnapshots: prometheus.NewDesc("rds_quota_maximum_db_instance_snapshots_average",
 			"Maximum number of manual DB instance snapshots",
-			nil, nil,
+			[]string{"aws_account_id", "aws_region"}, nil,
 		),
 		usageAllocatedStorage: prometheus.NewDesc("rds_usage_allocated_storage_average",
 			"Total storage used by AWS RDS instances",
-			nil, nil,
+			[]string{"aws_account_id", "aws_region"}, nil,
 		),
 		usageDBInstances: prometheus.NewDesc("rds_usage_db_instances_average",
 			"AWS RDS instance count",
-			nil, nil,
+			[]string{"aws_account_id", "aws_region"}, nil,
 		),
 		usageManualSnapshots: prometheus.NewDesc("rds_usage_manual_snapshots_average",
 			"Manual snapshots count",
-			nil, nil,
+			[]string{"aws_account_id", "aws_region"}, nil,
 		),
 	}
 }
@@ -383,56 +387,54 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.up, prometheus.CounterValue, exporterUpStatusCode)
 
 	// RDS metrics
-	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.rdsAPIcalls, "rds")
+	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.rdsAPIcalls, c.awsAccountID, c.awsRegion, "rds")
 	for dbidentifier, instance := range c.metrics.rds.Instances {
-		ch <- prometheus.MustNewConstMetric(c.allocatedStorage, prometheus.GaugeValue, float64(instance.AllocatedStorage), dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.information, prometheus.GaugeValue, 1, dbidentifier, instance.DbiResourceID, instance.DBInstanceClass, instance.Engine, instance.EngineVersion, instance.StorageType, strconv.FormatBool(instance.MultiAZ), strconv.FormatBool(instance.DeletionProtection), instance.Role, instance.SourceDBInstanceIdentifier, strconv.FormatBool(instance.PendingModifiedValues), instance.PendingMaintenanceAction)
-		ch <- prometheus.MustNewConstMetric(c.logFilesSize, prometheus.GaugeValue, float64(instance.LogFilesSize), dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.maxAllocatedStorage, prometheus.GaugeValue, float64(instance.MaxAllocatedStorage), dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.maxIops, prometheus.GaugeValue, float64(instance.MaxIops), dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.status, prometheus.GaugeValue, float64(instance.Status), dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.storageThroughput, prometheus.GaugeValue, float64(instance.StorageThroughput), dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.backupRetentionPeriod, prometheus.GaugeValue, float64(instance.BackupRetentionPeriod), dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.allocatedStorage, prometheus.GaugeValue, float64(instance.AllocatedStorage), c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.information, prometheus.GaugeValue, 1, c.awsAccountID, c.awsRegion, dbidentifier, instance.DbiResourceID, instance.DBInstanceClass, instance.Engine, instance.EngineVersion, instance.StorageType, strconv.FormatBool(instance.MultiAZ), strconv.FormatBool(instance.DeletionProtection), instance.Role, instance.SourceDBInstanceIdentifier, strconv.FormatBool(instance.PendingModifiedValues), instance.PendingMaintenanceAction)
+		ch <- prometheus.MustNewConstMetric(c.logFilesSize, prometheus.GaugeValue, float64(instance.LogFilesSize), c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.maxAllocatedStorage, prometheus.GaugeValue, float64(instance.MaxAllocatedStorage), c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.maxIops, prometheus.GaugeValue, float64(instance.MaxIops), c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.status, prometheus.GaugeValue, float64(instance.Status), c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.storageThroughput, prometheus.GaugeValue, float64(instance.StorageThroughput), c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.backupRetentionPeriod, prometheus.GaugeValue, float64(instance.BackupRetentionPeriod), c.awsAccountID, c.awsRegion, dbidentifier)
 	}
 
 	// Cloudwatch metrics
-	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.cloudwatchAPICalls, "cloudwatch")
+	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.cloudwatchAPICalls, c.awsAccountID, c.awsRegion, "cloudwatch")
 	for dbidentifier, instance := range c.metrics.cloudwatchInstances.Instances {
-		ch <- prometheus.MustNewConstMetric(c.cpuUtilisation, prometheus.GaugeValue, instance.CPUUtilization, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.databaseConnections, prometheus.GaugeValue, instance.DatabaseConnections, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.freeStorageSpace, prometheus.GaugeValue, instance.FreeStorageSpace, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.freeableMemory, prometheus.GaugeValue, instance.FreeableMemory, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.maximumUsedTransactionIDs, prometheus.GaugeValue, instance.MaximumUsedTransactionIDs, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.readIOPS, prometheus.GaugeValue, instance.ReadIOPS, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.readThroughput, prometheus.GaugeValue, instance.ReadThroughput, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.replicaLag, prometheus.GaugeValue, instance.ReplicaLag, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.replicationSlotDiskUsage, prometheus.GaugeValue, instance.ReplicationSlotDiskUsage, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.swapUsage, prometheus.GaugeValue, instance.SwapUsage, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.writeIOPS, prometheus.GaugeValue, instance.WriteIOPS, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.writeThroughput, prometheus.GaugeValue, instance.WriteThroughput, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.DBLoad, prometheus.GaugeValue, instance.DBLoad, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.dBLoadCPU, prometheus.GaugeValue, instance.DBLoadCPU, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.dBLoadNonCPU, prometheus.GaugeValue, instance.DBLoadNonCPU, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.databaseConnections, prometheus.GaugeValue, instance.DatabaseConnections, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.freeStorageSpace, prometheus.GaugeValue, instance.FreeStorageSpace, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.freeableMemory, prometheus.GaugeValue, instance.FreeableMemory, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.maximumUsedTransactionIDs, prometheus.GaugeValue, instance.MaximumUsedTransactionIDs, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.readThroughput, prometheus.GaugeValue, instance.ReadThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.replicaLag, prometheus.GaugeValue, instance.ReplicaLag, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.replicationSlotDiskUsage, prometheus.GaugeValue, instance.ReplicationSlotDiskUsage, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.swapUsage, prometheus.GaugeValue, instance.SwapUsage, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.writeIOPS, prometheus.GaugeValue, instance.WriteIOPS, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.writeThroughput, prometheus.GaugeValue, instance.WriteThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.DBLoad, prometheus.GaugeValue, instance.DBLoad, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.dBLoadCPU, prometheus.GaugeValue, instance.DBLoadCPU, c.awsAccountID, c.awsRegion, dbidentifier)
+		ch <- prometheus.MustNewConstMetric(c.dBLoadNonCPU, prometheus.GaugeValue, instance.DBLoadNonCPU, c.awsAccountID, c.awsRegion, dbidentifier)
 	}
 
 	// usage metrics
-	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.usageAPIcalls, "usage")
-	ch <- prometheus.MustNewConstMetric(c.usageAllocatedStorage, prometheus.GaugeValue, c.metrics.cloudWatchUsage.AllocatedStorage)
-	ch <- prometheus.MustNewConstMetric(c.usageDBInstances, prometheus.GaugeValue, c.metrics.cloudWatchUsage.DBInstances)
-	ch <- prometheus.MustNewConstMetric(c.usageManualSnapshots, prometheus.GaugeValue, c.metrics.cloudWatchUsage.ManualSnapshots)
+	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.usageAPIcalls, c.awsAccountID, c.awsRegion, "usage")
+	ch <- prometheus.MustNewConstMetric(c.usageAllocatedStorage, prometheus.GaugeValue, c.metrics.cloudWatchUsage.AllocatedStorage, c.awsAccountID, c.awsRegion)
+	ch <- prometheus.MustNewConstMetric(c.usageDBInstances, prometheus.GaugeValue, c.metrics.cloudWatchUsage.DBInstances, c.awsAccountID, c.awsRegion)
+	ch <- prometheus.MustNewConstMetric(c.usageManualSnapshots, prometheus.GaugeValue, c.metrics.cloudWatchUsage.ManualSnapshots, c.awsAccountID, c.awsRegion)
 
 	// EC2 metrics
-	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.ec2APIcalls, "ec2")
+	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.ec2APIcalls, c.awsAccountID, c.awsRegion, "ec2")
 	for instanceType, instance := range c.metrics.ec2.Instances {
-		ch <- prometheus.MustNewConstMetric(c.instanceMaximumIops, prometheus.GaugeValue, float64(instance.MaximumIops), instanceType)
-		ch <- prometheus.MustNewConstMetric(c.instanceMaximumThroughput, prometheus.GaugeValue, instance.MaximumThroughput, instanceType)
-		ch <- prometheus.MustNewConstMetric(c.instanceMemory, prometheus.GaugeValue, float64(instance.Memory), instanceType)
-		ch <- prometheus.MustNewConstMetric(c.instanceVCPU, prometheus.GaugeValue, float64(instance.Vcpu), instanceType)
+		ch <- prometheus.MustNewConstMetric(c.instanceMaximumIops, prometheus.GaugeValue, float64(instance.MaximumIops), instanceType, c.awsAccountID, c.awsRegion)
+		ch <- prometheus.MustNewConstMetric(c.instanceMaximumThroughput, prometheus.GaugeValue, instance.MaximumThroughput, instanceType, c.awsAccountID, c.awsRegion)
+		ch <- prometheus.MustNewConstMetric(c.instanceMemory, prometheus.GaugeValue, float64(instance.Memory), instanceType, c.awsAccountID, c.awsRegion)
+		ch <- prometheus.MustNewConstMetric(c.instanceVCPU, prometheus.GaugeValue, float64(instance.Vcpu), instanceType, c.awsAccountID, c.awsRegion)
 	}
 
 	// serviceQuotas metrics
-	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.serviceQuotasAPICalls, "servicequotas")
-	ch <- prometheus.MustNewConstMetric(c.quotaDBInstances, prometheus.GaugeValue, c.metrics.serviceQuota.DBinstances)
-	ch <- prometheus.MustNewConstMetric(c.quotaTotalStorage, prometheus.GaugeValue, c.metrics.serviceQuota.TotalStorage)
-	ch <- prometheus.MustNewConstMetric(c.quotaMaxDBInstanceSnapshots, prometheus.GaugeValue, c.metrics.serviceQuota.ManualDBInstanceSnapshots)
+	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.serviceQuotasAPICalls, c.awsAccountID, c.awsRegion, "servicequotas")
+	ch <- prometheus.MustNewConstMetric(c.quotaDBInstances, prometheus.GaugeValue, c.metrics.serviceQuota.DBinstances, c.awsAccountID, c.awsRegion)
+	ch <- prometheus.MustNewConstMetric(c.quotaTotalStorage, prometheus.GaugeValue, c.metrics.serviceQuota.TotalStorage, c.awsAccountID, c.awsRegion)
+	ch <- prometheus.MustNewConstMetric(c.quotaMaxDBInstanceSnapshots, prometheus.GaugeValue, c.metrics.serviceQuota.ManualDBInstanceSnapshots, c.awsAccountID, c.awsRegion)
 }


### PR DESCRIPTION
# Objective

Add AWS account ID and region labels

# Why

AWS customers may have RDS instances with the same name in different AWS accounts or/and regions.

When a single Prometheus deployment collects metrics for different it may lead to conflict.

# How

- Add `aws_account_id` and `aws_region` labels
- Document metrics's labels in the README

# Release plan

- [ ] Merge this PR