### PR TITLE
Rename rds_instance_maxIops_average to rds_instance_max_iops_average

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It collect key metrics about:
 | rds_freeable_memory_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of available random access memory. For MariaDB, MySQL, Oracle, and PostgreSQL DB instances, this metric reports the value of the MemAvailable field of /proc/meminfo |
 | rds_instance_info | `aws_account_id`, `aws_region`, `dbi_resource_id`, `dbidentifier`, `deletion_protection`, `engine`, `engine_version`, `instance_class`, `multi_az`, `pending_maintenance`, `pending_modified_values`, `role`, `source_dbidentifier`, `storage_type` | RDS instance information |
 | rds_instance_log_files_size_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Total of log files on the instance |
-| rds_instance_maxIops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum IOPS of underlying EC2 instance |
+| rds_instance_max_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum IOPS of underlying EC2 instance |
 | rds_instance_max_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum throughput of underlying EC2 instance |
 | rds_instance_memory_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Instance memory |
 | rds_instance_status | `aws_account_id`, `aws_region`, `dbidentifier` | Instance status (1: ok, 0: can't scrap metrics) |

--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -159,7 +159,7 @@ func NewCollector(logger slog.Logger, awsAccountID string, awsRegion string, rds
 			"Maximum throughput of underlying EC2 instance",
 			[]string{"aws_account_id", "aws_region", "instance_class"}, nil,
 		),
-		instanceMaximumIops: prometheus.NewDesc("rds_instance_maxIops_average",
+		instanceMaximumIops: prometheus.NewDesc("rds_instance_max_iops_average",
 			"Maximum IOPS of underlying EC2 instance",
 			[]string{"aws_account_id", "aws_region", "instance_class"}, nil,
 		),


### PR DESCRIPTION
# Objective

Rename rds_instance_maxIops_average to rds_instance_max_iops_average

# Why

Have consistency in metrics name

# How

Rename `rds_instance_maxIops_average` to `rds_instance_max_iops_average`

# Release plan

- [ ] Merge this PR
- [ ] Update Grafana dashboards & alerts to reflect this breaking change