### PR TITLE
Add well-known Kubernetes labels

### DIFF
--- a/configs/helm/templates/_helpers.tpl
+++ b/configs/helm/templates/_helpers.tpl
@@ -39,6 +39,8 @@ helm.sh/chart: {{ include "prometheus-rds-exporter.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+app.kubernetes.io/component: exporter
+app.kubernetes.io/part-of: database-monitoring-framework
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- range $key, $value := .Values.additionalLabels }}
 {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
# Objective

Add well-known Kubernetes labels

# Why

Facilitate Kubernetes audit and use standard configuration.

See https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

# How

- Add `app.kubernetes.io/name`, `app.kubernetes.io/component` and `app.kubernetes.io/part-of`

# Release plan

- [ ] Merge this PR