### PR TITLE
Fix region and linter

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,7 @@
+# https://github.com/DavidAnson/markdownlint
+
+# MD013/line-length - Line length
+MD013: false
+
+# MD033/no-inline-html - Inline HTML
+MD033: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,7 @@ repos:
     rev: v1.0.3
     hooks:
       - id: gofumpt # requires github.com/mvdan/gofumpt
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.37.0
+    hooks:
+    - id: markdownlint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,13 @@ make build
 make test         # Make sure all the tests pass before you commit and push :)
 ```
 
-We use [`golangci-lint`](https://github.com/golangci/golangci-lint) for linting the code. If it reports an issue and you think that the warning needs to be disregarded or is a false-positive, you can add a special comment `//nolint:linter1[,linter2,...]` before the offending line. Use this sparingly though, fixing the code to comply with the linter's recommendation is in general the preferred course of action.
+We use:
 
-We also use [`pre-commit`](https://pre-commit.com) to make perfect commits. Enable it for this repository with `pre-commit install`.
+* [`pre-commit`](https://pre-commit.com) to make right first time changes. Enable it for this repository with `pre-commit install`.
+
+* [`golangci-lint`](https://github.com/golangci/golangci-lint) for linting the code. If it reports an issue and you think that the warning needs to be disregarded or is a false-positive, you can add a special comment `//nolint:linter1[,linter2,...]` before the offending line. Use this sparingly though, fixing the code to comply with the linter's recommendation is in general the preferred course of action.
+
+* [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) for linting the Markdown documents.
 
 ## Pull Request Checklist
 
@@ -67,6 +71,18 @@ GO111MODULE=on go mod tidy
 ```
 
 You have to commit the changes to `go.mod` and `go.sum` before submitting the pull request.
+
+## Install pre-commit
+
+1. Install [pre-commit](https://pre-commit.com/)
+
+1. Install [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
+
+1. Enable pre-commit for the repository
+
+    ```bash
+    pre-commit install
+    ```
 
 ## Update dashboard
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Configuration could be defined in `.prometheus-rds-exporter.yaml` or environment
 | aws-assume-role-session | AWS assume role session name | prometheus-rds-exporter |
 | debug | Enable debug mode | |
 | listen-address | Address to listen on for web interface | :9043 |
-| log-format | Log format (`text` or `json`) | text |
+| log-format | Log format (`text` or `json`) | json |
 | metrics-path | Path under which to expose metrics | /metrics |
 
 Configuration parameters priorities:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Are you ready to take your AWS RDS monitoring to the next level? Say hello to pr
 Built by SRE Engineers, designed for production: Meticulously crafted by a team of Site Reliability Engineers with years of hands-on experience in managing RDS production systems. Trust in their expertise to supercharge your monitoring.
 
 It collect key metrics about:
+
 - Hardware resource usage
 - Underlying EC2 instances hard limits
 - Pending AWS RDS maintenances
@@ -12,7 +13,7 @@ It collect key metrics about:
 - Logs size
 - RDS quota usage information
 
-### Key metrics
+## Key metrics
 
 📊 Advanced Metrics: Gain deep visibility with advanced metrics for AWS RDS. Monitor performance, query efficiency, and resource utilization like never before.
 
@@ -160,9 +161,9 @@ Configuration parameters priorities:
 
 Prometheus RDS exporter needs read only AWS IAM permissions to fetch metrics from AWS RDS, CloudWatch, EC2 and ServiceQuota AWS APIs.
 
-Standard AWS authentication methods (AWS credentials, SSO and assume role), see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html.
+Standard AWS authentication methods (AWS credentials, SSO and assume role), see <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html>.
 
-If you are running on [AWS EKS](), we strongly recommend to use [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+If you are running on [AWS EKS](https://aws.amazon.com/eks/), we strongly recommend to use [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
 
 Minimal required IAM permissions:
 
@@ -288,6 +289,6 @@ It will start and configure Grafana, Prometheus, and the RDS exporter:
 
 1. Connect on the services
 
-    - Grafana: http://localhost:3000 (credential: admin/hackme)
-    - Prometheus: http://localhost:9090
-    - Prometheus RDS exporter: http://localhost:9043
+    - Grafana: <http://localhost:3000> (credential: admin/hackme)
+    - Prometheus: <http://localhost:9090>
+    - Prometheus RDS exporter: <http://localhost:9043>

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -38,5 +38,5 @@ func getAWSSessionInformation(cfg aws.Config) (string, string, error) {
 		return "", "", fmt.Errorf("can't fetch information about current session: %w", err)
 	}
 
-	return cfg.Region, *output.Account, nil
+	return *output.Account, cfg.Region, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,7 +97,7 @@ func NewRootCommand() (*cobra.Command, error) {
 
 	cmd.Flags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.prometheus-rds-exporter.yaml)")
 	cmd.Flags().BoolP("debug", "d", false, "Enable debug mode")
-	cmd.Flags().StringP("log-format", "l", "text", "Log format (text or json)")
+	cmd.Flags().StringP("log-format", "l", "json", "Log format (text or json)")
 	cmd.Flags().StringP("metrics-path", "", "/metrics", "Path under which to expose metrics")
 	cmd.Flags().StringP("listen-address", "", ":9043", "Address to listen on for web interface")
 	cmd.Flags().StringP("aws-assume-role-arn", "", "", "AWS IAM ARN role to assume to fetch metrics")

--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -426,10 +426,10 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 	// EC2 metrics
 	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.ec2APIcalls, c.awsAccountID, c.awsRegion, "ec2")
 	for instanceType, instance := range c.metrics.ec2.Instances {
-		ch <- prometheus.MustNewConstMetric(c.instanceMaximumIops, prometheus.GaugeValue, float64(instance.MaximumIops), instanceType, c.awsAccountID, c.awsRegion)
-		ch <- prometheus.MustNewConstMetric(c.instanceMaximumThroughput, prometheus.GaugeValue, instance.MaximumThroughput, instanceType, c.awsAccountID, c.awsRegion)
-		ch <- prometheus.MustNewConstMetric(c.instanceMemory, prometheus.GaugeValue, float64(instance.Memory), instanceType, c.awsAccountID, c.awsRegion)
-		ch <- prometheus.MustNewConstMetric(c.instanceVCPU, prometheus.GaugeValue, float64(instance.Vcpu), instanceType, c.awsAccountID, c.awsRegion)
+		ch <- prometheus.MustNewConstMetric(c.instanceMaximumIops, prometheus.GaugeValue, float64(instance.MaximumIops), c.awsAccountID, c.awsRegion, instanceType)
+		ch <- prometheus.MustNewConstMetric(c.instanceMaximumThroughput, prometheus.GaugeValue, instance.MaximumThroughput, c.awsAccountID, c.awsRegion, instanceType)
+		ch <- prometheus.MustNewConstMetric(c.instanceMemory, prometheus.GaugeValue, float64(instance.Memory), c.awsAccountID, c.awsRegion, instanceType)
+		ch <- prometheus.MustNewConstMetric(c.instanceVCPU, prometheus.GaugeValue, float64(instance.Vcpu), c.awsAccountID, c.awsRegion, instanceType)
 	}
 
 	// serviceQuotas metrics

--- a/scripts/prometheus/docker-compose.yml
+++ b/scripts/prometheus/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - AWS_PROFILE=${AWS_PROFILE-}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
+      - PROMETHEUS_RDS_EXPORTER_LOG_FORMAT=text
     volumes:
       - $HOME/.aws:/app/.aws:ro
       - ./../../rds_exporter:/mnt/rds_exporprometheus-rds-exporterter


### PR DESCRIPTION
# Objective

Fix aws labels and few improvements

# Why

aws_region and aws_account_id are incorrect on instance type metrics

# How

- Fix incorrect instance type labels
- Add Markdown linter
- Use JSON log format by default

# Release plan

- [ ] Merge this PR
- [ ] Release 0.2.2