### PR TITLE
Fix helm chart release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,5 +62,12 @@ jobs:
           registry-type: public
           mask-password: 'true'
 
+      - name: Downgrade Helm # 1.13.0 has bug that block push charts on OCI
+        run: |
+          curl -sSLo /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.12.0-linux-amd64.tar.gz" && \
+          tar --strip-components=1 -C /tmp -xzvf /tmp/helm.tar.gz linux-amd64/helm && \
+          mv /tmp/helm /usr/local/bin/helm && \
+          rm -f /tmp/helm.tar.gz
+
       - name: Helm release
         run: make helm-release


### PR DESCRIPTION
# Objective

Unblock Helm chart release process

# Why

Since Helm 1.13.0, helm can't publish Helm chart anymore, it received an HTTP 400.

We'll open & follow the issue with Helm, meanwhile, we downgrade it to 1.12.0.

# How

- Downgrade helm to 1.12.0

# Release plan

- [ ] Merge this PR
- [ ] Release missing chart version