### PR TITLE
Add Servicemonitor parameters

### DIFF
--- a/configs/helm/templates/servicemonitor.yaml
+++ b/configs/helm/templates/servicemonitor.yaml
@@ -11,10 +11,28 @@ metadata:
     {{- end }}
 spec:
   jobLabel: app.kubernetes.io/name # Ensure prometheus job name match application's name
+  sampleLimit: {{ .Values.serviceMonitor.sampleLimit }}
   endpoints:
     - path: /metrics
       port: http
       interval: {{ .Values.serviceMonitor.interval }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.externalLabels }}
+      externalLabels:
+        {{- with .Values.serviceMonitor.externalLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.serviceMonitor.relabelings | nindent 10 }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 10 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/configs/helm/tests/servicemonitor_test.yaml
+++ b/configs/helm/tests/servicemonitor_test.yaml
@@ -13,6 +13,9 @@ tests:
       - equal:
           path: spec.endpoints[0].interval
           value: 60s
+      - equal:
+          path: spec.sampleLimit
+          value: 0
   - it: render custom service monitor
     values:
       - ./values/with_servicemonitor.yaml
@@ -23,3 +26,34 @@ tests:
       - equal:
           path: metadata.labels.additionalLabel1
           value: value1
+  - it: render custom service monitor
+    values:
+      - ./values/with_servicemonitor.yaml
+    asserts:
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 120s
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 60s
+      - equal:
+          path: metadata.labels.additionalLabel1
+          value: value1
+      - equal:
+          path: spec.endpoints[0].externalLabels.externalLabel1
+          value: externalValue1
+      - equal:
+          path: spec.endpoints[0].relabelings[0].targetLabel
+          value: team
+      - equal:
+          path: spec.endpoints[0].relabelings[0].sourceLabels[0]
+          value: __meta_kubernetes_pod_label_team
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].sourceLabels[0]
+          value: __name__
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].regex
+          value: example
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].action
+          value: drop

--- a/configs/helm/tests/values/with_servicemonitor.yaml
+++ b/configs/helm/tests/values/with_servicemonitor.yaml
@@ -1,5 +1,17 @@
 serviceMonitor:
   enabled: true
   interval: 120s
+  scrapeTimeout: 60s
   additionalLabels:
     additionalLabel1: value1
+  externalLabels:
+    externalLabel1: externalValue1
+  sampleLimit: 42
+  relabelings:
+    - sourceLabels:
+        - __meta_kubernetes_pod_label_team
+      targetLabel: team
+  metricRelabelings:
+    - sourceLabels: [__name__]
+      regex: example
+      action: drop

--- a/configs/helm/values.yaml
+++ b/configs/helm/values.yaml
@@ -66,8 +66,12 @@ ingress:
 serviceMonitor:
   enabled: true
   interval: 60s
-  additionalLabels: {}
-
+  #scrapeTimeout: 30s
+  additionalLabels: {} # The labels to add on ServiceMonitor CRD
+  externalLabels: {} # The labels to add to any time series or alerts when communicating with external systems (federation, remote storage, Alertmanager)
+  relabelings: [] # RelabelConfigs to apply to samples before scraping
+  metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion
+  sampleLimit: 0 # SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.
 resources:
   limits:
     # cpu: 100m


### PR DESCRIPTION
# Objective

Add Servicemonitor parameter

# Why

Allow service monitor customization, see https://github.com/qonto/prometheus-rds-exporter/issues/13

# How

- Add `externalLabels`, `metricRelabelings`, `relabelings`, `sampleLimit`, and `scrapeTimeout` parameters

# Release plan

- [ ] Merge this PR