### PR TITLE
Fix Grafana broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,19 +120,19 @@ Grafana dashoards are available on Grafana labs:
 
 ![Instances overview](docs/screenshots/instances-overview.png)
 
-<a href="https://grafana.com/grafana/dashboards/19647-rds-instances-overview/">RDS instances overview</a> (ID `19647`)
+<a href="https://grafana.com/grafana/dashboards/19647/">RDS instances overview</a> (ID `19647`)
 </td>
 <td>
 
 ![Instance details](docs/screenshots/instance-details.png)
 
-<a href="https://grafana.com/grafana/dashboards/19646-rds-instance-details/">RDS instance details</a> (ID: `19646`)
+<a href="https://grafana.com/grafana/dashboards/19646/">RDS instance details</a> (ID: `19646`)
 </td>
 <td>
 
 ![RDS exporters](docs/screenshots/rds-exporter.png)
 
-<a href="https://grafana.com/grafana/dashboards/19679-rds-exporter/">RDS exporters</a> (ID: `19679`)
+<a href="https://grafana.com/grafana/dashboards/19679/">RDS exporters</a> (ID: `19679`)
 </td>
 </tr>
 </table>


### PR DESCRIPTION
# Objective

Fix Grafana's broken links

# Why

When a dashboard is renamed on Grafana.com it changes the URL of the page and leads to a 404 error.

Grafana automatically redirects if we use only the dashboard ID, so it's more future-proof if we want to change dashboard names.

Example

```
# Get dashboard with a name
curl -s -w "Code: %{response_code}\nRedirect: %header{location}\n"  https://grafana.com/grafana/dashboards/19646/any-name -o /dev/null
Code: 404
Redirect: 
```

```
# Get dashboard without name
curl -s -w "Code: %{response_code}\nRedirect: %header{location}\n"  https://grafana.com/grafana/dashboards/19646/ -o /dev/null
Code: 301
Redirect: /grafana/dashboards/19646-rds-instance-details/
````

# How

- Do not specify dashboard names in URL

# Release plan

- [ ] Merge this PR
