### PR TITLE
Consider unapplied parameter groups as pending modified values

### DIFF
--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -214,8 +214,17 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 	}
 
 	pendingModifiedValues := false
-	if !reflect.DeepEqual(dbInstance.PendingModifiedValues, &aws_rds_types.PendingModifiedValues{}) {
+
+	// PendingModifiedValues reports only instance changes
+	if dbInstance.PendingModifiedValues != nil && !reflect.DeepEqual(dbInstance.PendingModifiedValues, &aws_rds_types.PendingModifiedValues{}) {
 		pendingModifiedValues = true
+	}
+
+	// Report pending modified values if at lease one parameter group is not applied
+	for _, parameterGroup := range dbInstance.DBParameterGroups {
+		if *parameterGroup.ParameterApplyStatus != "in-sync" {
+			pendingModifiedValues = true
+		}
 	}
 
 	pendingMaintenanceAction := NoPendingMaintenanceOperation


### PR DESCRIPTION
# Objective

Consider unapplied parameter groups as pending modified values

# Why

An RDS instance should be considered as "pending modified values" when instance modifications are pending (current behavior) but also when parameter groups are unapplied.

It's common to see RDS instances running with pending parameter group in "pending-reboot" status. It's tricky to detect it from AWS RDS console because this information is only displayed in the configuration tab of each RDS instance.

<details>
<summary>Example</summary>

No maintenance on RDS instances list

![list](https://github.com/qonto/prometheus-rds-exporter/assets/319005/1f5b634f-82ac-4288-8800-c5ebd0c34150)

Parameter group are not applied

![details](https://github.com/qonto/prometheus-rds-exporter/assets/319005/8a1045ff-9797-47a3-837d-50e545711a11)

</details>

# How

- Add unapplied parameter group as condition to mark instance with "pending modified values"

# Release plan

- [ ] Merge this PR
- [ ] Apply with CI