### PR TITLE
fix(doc): Update .goreleaser.yaml: fix link to full changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -167,4 +167,4 @@ release:
     name: prometheus-rds-exporter
   name_template: "v{{.Version}}"
   footer: |
-    **Full Changelog**: https://github.com/qonto/poc-goreleaser/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/qonto/prometheus-rds-exporter/compare/{{ .PreviousTag }}...{{ .Tag }}


### PR DESCRIPTION
The link was wrong, pointing to a non-existing project.
