### PR TITLE
Settings improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 prometheus-rds-exporter
+prometheus-rds-exporter.yaml
 metrics
 
 # If you prefer the allow list template instead of the deny list, see community template:

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ go.work
 
 # Build files
 dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ Grafana dashoards are available on Grafana labs:
 
 ## Configuration
 
-Configuration could be defined in `.prometheus-rds-exporter.yaml` or environment variables (format `PROMETHEUS_RDS_EXPORTER_<PARAMETER_NAME>`).
+Configuration could be defined in [prometheus-rds-exporter.yaml](https://github.com/qonto/prometheus-rds-exporter/blob/main/configs/prometheus-rds-exporter/prometheus-rds-exporter.yaml) or environment variables (format `PROMETHEUS_RDS_EXPORTER_<PARAMETER_NAME>`).
 
 | Parameter | Description | Default |
 | --- | --- | --- |
 | aws-assume-role-arn | AWS IAM ARN role to assume to fetch metrics | |
 | aws-assume-role-session | AWS assume role session name | prometheus-rds-exporter |
-| collect-instances-metrics | Collect AWS instances metrics (AWS Cloudwatch API) | true |
+| collect-instance-metrics | Collect AWS instances metrics (AWS Cloudwatch API) | true |
 | collect-instance-types | Collect AWS instance types information (AWS EC2 API) | true |
 | collect-logs-size | Collect AWS instances logs size (AWS RDS API) | true |
 | collect-maintenances | Collect AWS instances maintenances (AWS RDS API) | true |
@@ -390,10 +390,10 @@ See [Development environment](#development-environment) to start the Prometheus 
 
     ```bash
     # Copy configuration template
-    cp /usr/share/prometheus-rds-exporter/prometheus-rds-exporter.yaml.sample /var/lib/prometheus-rds-exporter/.prometheus-rds-exporter.yaml
+    cp /usr/share/prometheus-rds-exporter/prometheus-rds-exporter.yaml.sample /var/lib/prometheus-rds-exporter/prometheus-rds-exporter.yaml
 
     # Edit configuration
-    vim /var/lib/prometheus-rds-exporter/.prometheus-rds-exporter.yaml
+    vim /var/lib/prometheus-rds-exporter/prometheus-rds-exporter.yaml
 
     # Restart service
     systemctl restart prometheus-rds-exporter
@@ -417,7 +417,7 @@ See [Development environment](#development-environment) to start the Prometheus 
     vim prometheus-rds-exporter.yaml
     ```
 
-1. Launch the exporter
+1. Start the exporter
 
     ```bash
     ./prometheus-rds-exporter

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,7 +110,7 @@ func NewRootCommand() (*cobra.Command, error) {
 
 	cobra.OnInitialize(initConfig)
 
-	cmd.Flags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.prometheus-rds-exporter.yaml)")
+	cmd.Flags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/prometheus-rds-exporter.yaml)")
 	cmd.Flags().BoolP("debug", "d", false, "Enable debug mode")
 	cmd.Flags().StringP("log-format", "l", "json", "Log format (text or json)")
 	cmd.Flags().StringP("metrics-path", "", "/metrics", "Path under which to expose metrics")
@@ -215,7 +215,7 @@ func initConfig() {
 		viper.AddConfigPath(".")
 		viper.AddConfigPath(home)
 		viper.SetConfigType("yaml")
-		viper.SetConfigName(".prometheus-rds-exporter")
+		viper.SetConfigName("prometheus-rds-exporter")
 	}
 
 	if err := viper.ReadInConfig(); err == nil {

--- a/configs/prometheus-rds-exporter/prometheus-rds-exporter.yaml
+++ b/configs/prometheus-rds-exporter/prometheus-rds-exporter.yaml
@@ -1,17 +1,47 @@
-# Log format (text or json)
-# log-format: json
+#
+# Exporter settings
+#
+
+# Enable debug mode
+#debug: false
 
 # Path under which to expose metrics
-# metrics-path: /metrics
+#metrics-path: /metrics
 
 # Address to listen on for web interface
-# listen-address: ":9043"
+#listen-address: ":9043"
 
-# AWS profile
-# aws-profile: my_profile
+# Log format (text or json)
+#log-format: json
+
+#
+# AWS credentials
+#
 
 # AWS IAM ARN role to assume to fetch metrics
-# aws-assume-role-arn: arn:aws:iam::000000000000:role/prometheus-rds-exporter
+#aws-assume-role-arn: arn:aws:iam::000000000000:role/prometheus-rds-exporter
 
 # AWS assume role session name
-# aws-assume-role-session: prometheus-rds-exporter
+#aws-assume-role-session: prometheus-rds-exporter
+
+#
+# Metrics
+#
+
+# Collect AWS instances metrics (AWS Cloudwatch API)
+#collect-instance-metrics: true
+
+# Collect AWS instance types information (AWS EC2 API)
+#collect-instance-types: true
+
+# Collect AWS instances logs size (AWS RDS API)
+#collect-logs-size: true
+
+# Collect AWS instances maintenances (AWS RDS API)
+#collect-maintenances: true
+
+# Collect AWS RDS quotas (AWS quotas API)
+#collect-quotas: true
+
+# Collect AWS RDS usages (AWS Cloudwatch API)
+#collect-usages: true

--- a/internal/infra/http/index.go
+++ b/internal/infra/http/index.go
@@ -7,7 +7,9 @@ import (
 	"github.com/qonto/prometheus-rds-exporter/internal/infra/build"
 )
 
-type homeHandler struct{}
+type homeHandler struct {
+	metricPath string
+}
 
 func (h homeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `<html>
@@ -16,7 +18,7 @@ func (h homeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		</head>
 		<body>
 			<h1>Prometheus RDS Exporter (%s)</h1>
-			<p><a href='/metrics'>Metrics</a></p>
+			<p><a href='%s'>Metrics</a></p>
 		</body>
-		</html>`, build.Version)
+		</html>`, build.Version, h.metricPath)
 }

--- a/internal/infra/http/index.go
+++ b/internal/infra/http/index.go
@@ -7,9 +7,9 @@ import (
 	"github.com/qonto/prometheus-rds-exporter/internal/infra/build"
 )
 
-type helloWorldhandler struct{}
+type homeHandler struct{}
 
-func (h helloWorldhandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h homeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `<html>
 		<head>
 			<title>Prometheus RDS Exporter</title>

--- a/internal/infra/http/server.go
+++ b/internal/infra/http/server.go
@@ -63,7 +63,7 @@ func (c *Component) Start() error {
 		BaseContext:       func(_ net.Listener) context.Context { return ctx },
 	}
 
-	http.Handle("/", homeHandler{})
+	http.Handle("/", homeHandler{metricPath: c.config.metricPath})
 	http.Handle(c.config.metricPath, promhttp.Handler())
 
 	signalChan := make(chan os.Signal, 1)

--- a/internal/infra/http/server.go
+++ b/internal/infra/http/server.go
@@ -63,7 +63,7 @@ func (c *Component) Start() error {
 		BaseContext:       func(_ net.Listener) context.Context { return ctx },
 	}
 
-	http.Handle("/", helloWorldhandler{})
+	http.Handle("/", homeHandler{})
 	http.Handle(c.config.metricPath, promhttp.Handler())
 
 	signalChan := make(chan os.Signal, 1)


### PR DESCRIPTION
# Objective

Facilitate settings

# Why

Using a hidden file configuration (.prometheus-rds-exporter.yaml) is not relevant for a service and should be fixed.

# How

- **Breaking change** Use `prometheus-rds-exporter.yaml` instead of `.prometheus-rds-exporter.yaml`
- Document all exporter settings (including the Debian package)
- Fix incorrect parameter in the README

# Release plan

- [ ] Merge this PR