### PR TITLE
Rename metrics without units

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ It collect key metrics about:
 | rds_replication_slot_disk_usage_average | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by replication slot files. Applies to PostgreSQL |
 | rds_swap_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of swap space used on the DB instance. This metric is not available for SQL Server |
 | rds_transaction_logs_disk_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by transaction logs (only on PostgreSQL) |
-| rds_usage_allocated_storage_average | `aws_account_id`, `aws_region` | Total storage used by AWS RDS instances |
+| rds_usage_allocated_storage_bytes | `aws_account_id`, `aws_region` | Total storage used by AWS RDS instances |
 | rds_usage_db_instances_average | `aws_account_id`, `aws_region` | AWS RDS instance count |
 | rds_usage_manual_snapshots_average | `aws_account_id`, `aws_region` | Manual snapshots count |
 | rds_write_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of disk write I/O operations per second |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It collect key metrics about:
 | rds_read_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of disk read I/O operations per second |
 | rds_read_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of bytes read from disk per second |
 | rds_replica_lag_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | For read replica configurations, the amount of time a read replica DB instance lags behind the source DB instance. Applies to MariaDB, Microsoft SQL Server, MySQL, Oracle, and PostgreSQL read replicas |
-| rds_replication_slot_disk_usage_average | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by replication slot files. Applies to PostgreSQL |
+| rds_replication_slot_disk_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by replication slot files. Applies to PostgreSQL |
 | rds_swap_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of swap space used on the DB instance. This metric is not available for SQL Server |
 | rds_transaction_logs_disk_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by transaction logs (only on PostgreSQL) |
 | rds_usage_allocated_storage_bytes | `aws_account_id`, `aws_region` | Total storage used by AWS RDS instances |

--- a/internal/app/cloudwatch/usage.go
+++ b/internal/app/cloudwatch/usage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_cloudwatch "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	aws_cloudwatch_types "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	converter "github.com/qonto/prometheus-rds-exporter/internal/app/unit"
 )
 
 type UsageMetrics struct {
@@ -22,7 +23,7 @@ type UsageMetrics struct {
 func (u *UsageMetrics) Update(field string, value float64) error {
 	switch field {
 	case "AllocatedStorage":
-		u.AllocatedStorage = value
+		u.AllocatedStorage = converter.GigaBytesToBytes(value)
 	case "DBInstances":
 		u.DBInstances = value
 	case "ManualSnapshots":

--- a/internal/app/cloudwatch/usage_test.go
+++ b/internal/app/cloudwatch/usage_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_cloudwatch_types "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/qonto/prometheus-rds-exporter/internal/app/cloudwatch"
+	converter "github.com/qonto/prometheus-rds-exporter/internal/app/unit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +45,7 @@ func TestGetUsageMetrics(t *testing.T) {
 	result, err := client.GetUsageMetrics()
 
 	require.NoError(t, err, "GetUsageMetrics must succeed")
-	assert.Equal(t, expected.AllocatedStorage, result.AllocatedStorage, "Allocated storage mismatch")
+	assert.Equal(t, converter.GigaBytesToBytes(expected.AllocatedStorage), result.AllocatedStorage, "Allocated storage mismatch")
 	assert.Equal(t, expected.DBInstances, result.DBInstances, "DB instances count mismatch")
 	assert.Equal(t, expected.ManualSnapshots, result.ManualSnapshots, "Manual snapshots mismatch")
 	assert.Equal(t, expected.ReservedDBInstances, result.ReservedDBInstances, "Reserved DB instances mismatch")

--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -262,7 +262,7 @@ func NewCollector(logger slog.Logger, collectorConfiguration Configuration, awsA
 			"Maximum number of manual DB instance snapshots",
 			[]string{"aws_account_id", "aws_region"}, nil,
 		),
-		usageAllocatedStorage: prometheus.NewDesc("rds_usage_allocated_storage_average",
+		usageAllocatedStorage: prometheus.NewDesc("rds_usage_allocated_storage_bytes",
 			"Total storage used by AWS RDS instances",
 			[]string{"aws_account_id", "aws_region"}, nil,
 		),

--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -210,7 +210,7 @@ func NewCollector(logger slog.Logger, collectorConfiguration Configuration, awsA
 			"For read replica configurations, the amount of time a read replica DB instance lags behind the source DB instance. Applies to MariaDB, Microsoft SQL Server, MySQL, Oracle, and PostgreSQL read replicas",
 			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
-		replicationSlotDiskUsage: prometheus.NewDesc("rds_replication_slot_disk_usage_average",
+		replicationSlotDiskUsage: prometheus.NewDesc("rds_replication_slot_disk_usage_bytes",
 			"Disk space used by replication slot files. Applies to PostgreSQL",
 			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -263,7 +263,7 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 	}
 
 	metrics := RdsInstanceMetrics{
-		AllocatedStorage:           converter.GigaBytesToBytes(dbInstance.AllocatedStorage),
+		AllocatedStorage:           converter.GigaBytesToBytes(int64(dbInstance.AllocatedStorage)),
 		BackupRetentionPeriod:      converter.DaystoSeconds(dbInstance.BackupRetentionPeriod),
 		DBInstanceClass:            *dbInstance.DBInstanceClass,
 		DbiResourceID:              *dbInstance.DbiResourceId,
@@ -271,7 +271,7 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 		Engine:                     *dbInstance.Engine,
 		EngineVersion:              *dbInstance.EngineVersion,
 		LogFilesSize:               logFilesSize,
-		MaxAllocatedStorage:        converter.GigaBytesToBytes(maxAllocatedStorage),
+		MaxAllocatedStorage:        converter.GigaBytesToBytes(int64(maxAllocatedStorage)),
 		MaxIops:                    iops,
 		MultiAZ:                    dbInstance.MultiAZ,
 		PendingMaintenanceAction:   pendingMaintenanceAction,

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -214,9 +214,9 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 
 	iops, storageThroughput := getStorageMetrics(*dbInstance.StorageType, int64(dbInstance.AllocatedStorage), iops, throughput)
 
-	var maxAllocatedStorage int32 = 0
+	var maxAllocatedStorage int64 = 0
 	if dbInstance.MaxAllocatedStorage != nil {
-		maxAllocatedStorage = *dbInstance.MaxAllocatedStorage
+		maxAllocatedStorage = int64(*dbInstance.MaxAllocatedStorage)
 	}
 
 	pendingModifiedValues := false
@@ -271,7 +271,7 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 		Engine:                     *dbInstance.Engine,
 		EngineVersion:              *dbInstance.EngineVersion,
 		LogFilesSize:               logFilesSize,
-		MaxAllocatedStorage:        converter.GigaBytesToBytes(int64(maxAllocatedStorage)),
+		MaxAllocatedStorage:        converter.GigaBytesToBytes(maxAllocatedStorage),
 		MaxIops:                    iops,
 		MultiAZ:                    dbInstance.MultiAZ,
 		PendingMaintenanceAction:   pendingMaintenanceAction,

--- a/internal/app/rds/rds_test.go
+++ b/internal/app/rds/rds_test.go
@@ -111,8 +111,8 @@ func TestGetMetrics(t *testing.T) {
 	assert.Equal(t, "primary", m.Role, "Should be primary node")
 	assert.Equal(t, emptyInt64, m.LogFilesSize, "Log file size mismatch")
 
-	assert.Equal(t, converter.GigaBytesToBytes(rdsInstance.AllocatedStorage), m.AllocatedStorage, "Allocated storage mismatch")
-	assert.Equal(t, converter.GigaBytesToBytes(*rdsInstance.MaxAllocatedStorage), m.MaxAllocatedStorage, "Max allocated storage (aka autoscaling) mismatch")
+	assert.Equal(t, converter.GigaBytesToBytes(int64(rdsInstance.AllocatedStorage)), m.AllocatedStorage, "Allocated storage mismatch")
+	assert.Equal(t, converter.GigaBytesToBytes(int64(*rdsInstance.MaxAllocatedStorage)), m.MaxAllocatedStorage, "Max allocated storage (aka autoscaling) mismatch")
 	assert.Equal(t, int64(*rdsInstance.Iops), m.MaxIops, "Max IOPS mismatch")
 	assert.Equal(t, converter.DaystoSeconds(rdsInstance.BackupRetentionPeriod), m.BackupRetentionPeriod, "Backup retention mismatch")
 	assert.Equal(t, rdsInstance.DeletionProtection, m.DeletionProtection, "Deletion protection mismatch")

--- a/internal/app/servicequotas/servicequotas.go
+++ b/internal/app/servicequotas/servicequotas.go
@@ -103,7 +103,7 @@ func (s *serviceQuotaFetcher) GetRDSQuotas() (Metrics, error) {
 
 	return Metrics{
 		DBinstances:               DBinstances,
-		TotalStorage:              float64(converter.GigaBytesToBytes(totalStorage)),
+		TotalStorage:              converter.GigaBytesToBytes(totalStorage),
 		ManualDBInstanceSnapshots: manualDBInstanceSnapshots,
 	}, nil
 }

--- a/internal/app/servicequotas/servicequotas_test.go
+++ b/internal/app/servicequotas/servicequotas_test.go
@@ -49,6 +49,6 @@ func TestGetRDSQuotas(t *testing.T) {
 	result, err := servicequotas.NewFetcher(mockClient).GetRDSQuotas()
 	require.NoError(t, err, "GetRDSQuotas must succeed")
 	assert.Equal(t, DBinstancesQuota, result.DBinstances, "DbInstance quota is incorrect")
-	assert.Equal(t, float64(converter.GigaBytesToBytes(totalStorage)), result.TotalStorage, "Total storage quota is incorrect")
+	assert.Equal(t, converter.GigaBytesToBytes(totalStorage), result.TotalStorage, "Total storage quota is incorrect")
 	assert.Equal(t, manualDBInstanceSnapshots, result.ManualDBInstanceSnapshots, "Manual db instance snapshot quota is incorrect")
 }

--- a/internal/app/unit/converter.go
+++ b/internal/app/unit/converter.go
@@ -10,8 +10,8 @@ type Number interface {
 	int32 | int64 | float64
 }
 
-func GigaBytesToBytes[N Number](size N) int64 {
-	return int64(size) * unit * unit * unit
+func GigaBytesToBytes[N Number](size N) N {
+	return size * unit * unit * unit
 }
 
 func MegaBytesToBytes[N Number](size N) N {

--- a/internal/app/unit/converter_test.go
+++ b/internal/app/unit/converter_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestGigaBytesToBytes(t *testing.T) {
-	assert.Equal(t, int64(1073741824), converter.GigaBytesToBytes(int32(1)), "1 GB conversion is not correct")
+	assert.Equal(t, int32(1073741824), converter.GigaBytesToBytes(int32(1)), "1 GB conversion is not correct")
 	assert.Equal(t, int64(1073741824), converter.GigaBytesToBytes(int64(1)), "1 GB conversion is not correct")
-	assert.Equal(t, int64(1073741824), converter.GigaBytesToBytes(float64(1)), "1 GB conversion is not correct")
+	assert.Equal(t, float64(1073741824), converter.GigaBytesToBytes(float64(1)), "1 GB conversion is not correct")
 }
 
 func TestMegaBytesToBytes(t *testing.T) {


### PR DESCRIPTION
# Objective

Specify units for `rds_replication_slot_disk_usage_average` and `rds_usage_allocated_storage_average`

# Why

According to [Prometheus metrics best practices](https://prometheus.io/docs/practices/naming/), these metrics should contain the `_bytes` suffix instead of `_average`

`rds_usage_allocated_storage_average` was specified in Gigabytes while it should be in Bytes.

# How

- Rename `rds_replication_slot_disk_usage_average` to `rds_replication_slot_disk_usage_bytes`
- Rename `rds_usage_allocated_storage_average` to `rds_usage_allocated_storage_bytes`

Issue was reported by end-user in https://github.com/qonto/prometheus-rds-exporter/issues/32

# Release plan

- [ ] Merge this PR
- [ ] Update metrics in Grafana dashboards
- [ ] Update alerts in Database Monitoring Framework