### PR TITLE
Add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,9 @@ You can take example on Terraform code in `configs/terraform/`.
 
 ## Contribute
 
-See [CONTRIBUTING.md](CONTRIBUTING.md)
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+To report a security issue, please visit [SECURITY.md](SECURITY.md)
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Qonto team and community take security bugs in Prometheus RDS exporter seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory [Report a Vulnerability](https://github.com/qonto/prometheus-rds-exporter/security/advisories/new) tab.
+
+The Qonto team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.


### PR DESCRIPTION
# Objective

Add security policy

# Why

Explain how users should report security vulnerabilities for this repository.

It's also the latest Github security feature to enable:

<img width="977" alt="screenshot 2023-11-15 at 22 38 18" src="https://github.com/qonto/prometheus-rds-exporter/assets/319005/889415b4-82be-426a-b934-239eb977634a">

# How

- Add security.md

# Release plan

- [ ] Merge this PR