### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**Desktop (please complete the following information):**
+
+ - OS: [e.g. Linux]
+ - Prometheus RDS exporter's version [e.g. 1.1]
+ - RDS engine: [e.g. PostgreSQL]
+
+**To Reproduce**
+
+Steps to reproduce the behavior
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
# Objective

Add issue templates

# Why

Facilitate issue creation by providing template

# How

- Add built-in Github issue templates

# Release plan

- [ ] Merge this PR
- [ ] Apply with CI