### PR TITLE
chore(metrics): Export RDS Certificate Authority attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It collect key metrics about:
 | rds_allocated_storage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Allocated storage |
 | rds_api_call_total | `api`, `aws_account_id`, `aws_region` | Number of call to AWS API |
 | rds_backup_retention_period_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | Automatic DB snapshots retention period |
+| rds_ca_certificate_valid_until | `aws_account_id`, `aws_region`, `dbidentifier` | Timestamp of the expiration of the Instance certificate |
 | rds_cpu_usage_percent_average | `aws_account_id`, `aws_region`, `dbidentifier` | Instance CPU used |
 | rds_database_connections_average | `aws_account_id`, `aws_region`, `dbidentifier` | The number of client network connections to the database instance |
 | rds_dbload_average | `aws_account_id`, `aws_region`, `dbidentifier` | Number of active sessions for the DB engine |

--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -126,7 +126,7 @@ func NewCollector(logger slog.Logger, collectorConfiguration Configuration, awsA
 		),
 		information: prometheus.NewDesc("rds_instance_info",
 			"RDS instance information",
-			[]string{"aws_account_id", "aws_region", "dbidentifier", "dbi_resource_id", "instance_class", "engine", "engine_version", "storage_type", "multi_az", "deletion_protection", "role", "source_dbidentifier", "pending_modified_values", "pending_maintenance", "performance_insights_enabled"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier", "dbi_resource_id", "instance_class", "engine", "engine_version", "storage_type", "multi_az", "deletion_protection", "role", "source_dbidentifier", "pending_modified_values", "pending_maintenance", "performance_insights_enabled", "ca_certificate_identifier"}, nil,
 		),
 		maxAllocatedStorage: prometheus.NewDesc("rds_max_allocated_storage_bytes",
 			"Upper limit in gibibytes to which Amazon RDS can automatically scale the storage of the DB instance",
@@ -415,8 +415,33 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 	// RDS metrics
 	ch <- prometheus.MustNewConstMetric(c.apiCall, prometheus.CounterValue, c.counters.rdsAPIcalls, c.awsAccountID, c.awsRegion, "rds")
 	for dbidentifier, instance := range c.metrics.rds.Instances {
-		ch <- prometheus.MustNewConstMetric(c.allocatedStorage, prometheus.GaugeValue, float64(instance.AllocatedStorage), c.awsAccountID, c.awsRegion, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.information, prometheus.GaugeValue, 1, c.awsAccountID, c.awsRegion, dbidentifier, instance.DbiResourceID, instance.DBInstanceClass, instance.Engine, instance.EngineVersion, instance.StorageType, strconv.FormatBool(instance.MultiAZ), strconv.FormatBool(instance.DeletionProtection), instance.Role, instance.SourceDBInstanceIdentifier, strconv.FormatBool(instance.PendingModifiedValues), instance.PendingMaintenanceAction, strconv.FormatBool(instance.PerformanceInsightsEnabled))
+		ch <- prometheus.MustNewConstMetric(
+			c.allocatedStorage,
+			prometheus.GaugeValue,
+			float64(instance.AllocatedStorage),
+			c.awsAccountID, c.awsRegion, dbidentifier,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.information,
+			prometheus.GaugeValue,
+			1,
+			c.awsAccountID,
+			c.awsRegion,
+			dbidentifier,
+			instance.DbiResourceID,
+			instance.DBInstanceClass,
+			instance.Engine,
+			instance.EngineVersion,
+			instance.StorageType,
+			strconv.FormatBool(instance.MultiAZ),
+			strconv.FormatBool(instance.DeletionProtection),
+			instance.Role,
+			instance.SourceDBInstanceIdentifier,
+			strconv.FormatBool(instance.PendingModifiedValues),
+			instance.PendingMaintenanceAction,
+			strconv.FormatBool(instance.PerformanceInsightsEnabled),
+			instance.CACertificateIdentifier,
+		)
 		ch <- prometheus.MustNewConstMetric(c.maxAllocatedStorage, prometheus.GaugeValue, float64(instance.MaxAllocatedStorage), c.awsAccountID, c.awsRegion, dbidentifier)
 		ch <- prometheus.MustNewConstMetric(c.maxIops, prometheus.GaugeValue, float64(instance.MaxIops), c.awsAccountID, c.awsRegion, dbidentifier)
 		ch <- prometheus.MustNewConstMetric(c.status, prometheus.GaugeValue, float64(instance.Status), c.awsAccountID, c.awsRegion, dbidentifier)

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -48,6 +48,7 @@ type RdsInstanceMetrics struct {
 	IAMDatabaseAuthenticationEnabled bool
 	Role                             string
 	SourceDBInstanceIdentifier       string
+	CACertificateIdentifier          string
 }
 
 const (
@@ -272,6 +273,7 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 		Status:                     GetDBInstanceStatusCode(*dbInstance.DBInstanceStatus),
 		StorageThroughput:          converter.MegaBytesToBytes(storageThroughput),
 		StorageType:                *dbInstance.StorageType,
+		CACertificateIdentifier:    *dbInstance.CACertificateIdentifier,
 	}
 
 	return metrics, nil

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_rds "github.com/aws/aws-sdk-go-v2/service/rds"
@@ -49,6 +50,7 @@ type RdsInstanceMetrics struct {
 	Role                             string
 	SourceDBInstanceIdentifier       string
 	CACertificateIdentifier          string
+	CertificateValidTill             time.Time
 }
 
 const (
@@ -274,6 +276,7 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 		StorageThroughput:          converter.MegaBytesToBytes(storageThroughput),
 		StorageType:                *dbInstance.StorageType,
 		CACertificateIdentifier:    *dbInstance.CACertificateIdentifier,
+		CertificateValidTill:       *dbInstance.CertificateDetails.ValidTill,
 	}
 
 	return metrics, nil

--- a/internal/app/rds/rds_test.go
+++ b/internal/app/rds/rds_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_rds "github.com/aws/aws-sdk-go-v2/service/rds"
@@ -55,6 +56,16 @@ func randomString(length int) string {
 	return fmt.Sprintf("%x", buf)
 }
 
+func newRdsCertificateDetails() *aws_rds_types.CertificateDetails {
+	return &aws_rds_types.CertificateDetails{
+		CAIdentifier: aws.String("rds-ca-2019"),
+		ValidTill: aws.Time(time.Date(
+			2024, time.August, 22,
+			17, 8, 50, 0, time.UTC,
+		)),
+	}
+}
+
 func newRdsInstance() *aws_rds_types.DBInstance {
 	DBInstanceIdentifier := randomString(10)
 
@@ -76,6 +87,7 @@ func newRdsInstance() *aws_rds_types.DBInstance {
 		PubliclyAccessible:         true,
 		StorageType:                aws.String("gp3"),
 		CACertificateIdentifier:    aws.String("rds-ca-2019"),
+		CertificateDetails:         newRdsCertificateDetails(),
 	}
 }
 
@@ -110,6 +122,7 @@ func TestGetMetrics(t *testing.T) {
 	assert.Equal(t, *rdsInstance.DbiResourceId, m.DbiResourceID, "DbiResourceId mismatch")
 	assert.Equal(t, *rdsInstance.DBInstanceClass, m.DBInstanceClass, "DBInstanceIdentifier mismatch")
 	assert.Equal(t, *rdsInstance.CACertificateIdentifier, m.CACertificateIdentifier, "CACertificateIdentifier mismatch")
+	assert.Equal(t, *rdsInstance.CertificateDetails.ValidTill, m.CertificateValidTill, "CertificateValidTill mismatch")
 }
 
 func TestGP2StorageType(t *testing.T) {

--- a/internal/app/rds/rds_test.go
+++ b/internal/app/rds/rds_test.go
@@ -75,6 +75,7 @@ func newRdsInstance() *aws_rds_types.DBInstance {
 		PerformanceInsightsEnabled: aws.Bool(true),
 		PubliclyAccessible:         true,
 		StorageType:                aws.String("gp3"),
+		CACertificateIdentifier:    aws.String("rds-ca-2019"),
 	}
 }
 
@@ -108,6 +109,7 @@ func TestGetMetrics(t *testing.T) {
 	assert.Equal(t, rdsInstance.PubliclyAccessible, m.PubliclyAccessible, "PubliclyAccessible mismatch")
 	assert.Equal(t, *rdsInstance.DbiResourceId, m.DbiResourceID, "DbiResourceId mismatch")
 	assert.Equal(t, *rdsInstance.DBInstanceClass, m.DBInstanceClass, "DBInstanceIdentifier mismatch")
+	assert.Equal(t, *rdsInstance.CACertificateIdentifier, m.CACertificateIdentifier, "CACertificateIdentifier mismatch")
 }
 
 func TestGP2StorageType(t *testing.T) {


### PR DESCRIPTION
- The CA identifier is exposed as `ca_certificate_identifier` attribute of the `rds_instance_info` metric
- The Unix timestamp of the expiration date of the CA certificate is exposed in the `rds_ca_certificate_valid_until` gauge.

For the `rds-ca-2019` RDS CA, values are:
```
rds_instance_info{aws_account_id="012345678901",aws_region="eu-west-1",ca_certificate_identifier="rds-ca-2019",dbidentifier="rds-1",...}
rds_ca_certificate_valid_until{aws_account_id="012345678901",aws_region="eu-west-1",dbidentifier="rds-1"} 1.72434653e+09
```