### PR TITLE
Add instance age metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ It collect key metrics about:
 | rds_quota_total_storage_bytes | `aws_account_id`, `aws_region` | Maximum total storage for all DB instances |
 | rds_read_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of disk read I/O operations per second |
 | rds_read_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of bytes read from disk per second |
-| rds_transaction_logs_disk_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by transaction logs (only on PostgreSQL) |
 | rds_replica_lag_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | For read replica configurations, the amount of time a read replica DB instance lags behind the source DB instance. Applies to MariaDB, Microsoft SQL Server, MySQL, Oracle, and PostgreSQL read replicas |
 | rds_replication_slot_disk_usage_average | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by replication slot files. Applies to PostgreSQL |
 | rds_swap_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of swap space used on the DB instance. This metric is not available for SQL Server |
+| rds_transaction_logs_disk_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by transaction logs (only on PostgreSQL) |
 | rds_usage_allocated_storage_average | `aws_account_id`, `aws_region` | Total storage used by AWS RDS instances |
 | rds_usage_db_instances_average | `aws_account_id`, `aws_region` | AWS RDS instance count |
 | rds_usage_manual_snapshots_average | `aws_account_id`, `aws_region` | Manual snapshots count |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ It collect key metrics about:
 | rds_exporter_errors_total | | Total number of errors encountered by the exporter |
 | rds_free_storage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Free storage on the instance |
 | rds_freeable_memory_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of available random access memory. For MariaDB, MySQL, Oracle, and PostgreSQL DB instances, this metric reports the value of the MemAvailable field of /proc/meminfo |
+| rds_instance_age_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | Time since instance creation |
 | rds_instance_info | `aws_account_id`, `aws_region`, `dbi_resource_id`, `dbidentifier`, `deletion_protection`, `engine`, `engine_version`, `instance_class`, `multi_az`, `performance_insights_enabled`, `pending_maintenance`, `pending_modified_values`, `role`, `source_dbidentifier`, `storage_type` | RDS instance information |
 | rds_instance_log_files_size_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Total of log files on the instance |
 | rds_instance_max_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum IOPS of underlying EC2 instance |

--- a/docs/add-metric.md
+++ b/docs/add-metric.md
@@ -1,0 +1,31 @@
+# Add a metric
+
+This document explains how to add a new metric in the exporter:
+
+Requirements:
+
+- Metric must be relevant to create alert or visualization (🚩 Don't collect metrics just for convenient visualization)
+- Metric names and labels must follow the [Prometheus best practices](https://prometheus.io/docs/practices/naming/)
+
+Steps:
+
+1. Define metric names and labels
+
+1. Implement it
+
+    1. Add a new field in `rdsCollector` structure in `internal/app/exporter/exporter.go`
+    1. Add metrics description in `NewCollector()` function in `internal/app/exporter/exporter.go`
+    1. Collect the metrics
+    1. Export the result in `Collect()` in `internal/app/exporter/exporter.go`
+
+1. Add tests
+
+1. Test metrics in an AWS environment
+
+1. Add metric in the `README.md`
+
+1. Commit with `feat(metric): Add <metric> <short description>` message to mark it a new feature in the release's changelog.
+
+1. Optional. Update Grafana dashboards to display the metric
+
+1. Optional. Add alert using the new metric in [DMF](https://github.com/qonto/database-monitoring-framework)

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -51,6 +51,7 @@ type RdsInstanceMetrics struct {
 	SourceDBInstanceIdentifier       string
 	CACertificateIdentifier          string
 	CertificateValidTill             time.Time
+	Age                              *float64
 }
 
 const (
@@ -254,6 +255,13 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 
 	role, sourceDBInstanceIdentifier := getRoleInCluster(&dbInstance)
 
+	var age *float64
+
+	if dbInstance.InstanceCreateTime != nil {
+		diff := time.Since(*dbInstance.InstanceCreateTime).Seconds()
+		age = &diff
+	}
+
 	metrics := RdsInstanceMetrics{
 		AllocatedStorage:           converter.GigaBytesToBytes(dbInstance.AllocatedStorage),
 		BackupRetentionPeriod:      converter.DaystoSeconds(dbInstance.BackupRetentionPeriod),
@@ -277,6 +285,7 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 		StorageType:                *dbInstance.StorageType,
 		CACertificateIdentifier:    *dbInstance.CACertificateIdentifier,
 		CertificateValidTill:       *dbInstance.CertificateDetails.ValidTill,
+		Age:                        age,
 	}
 
 	return metrics, nil


### PR DESCRIPTION
# Objective

Add instance age metric

# Why

Some workloads require raising alerts based on instance age.

At Qonto, we raise alerts when some instances (based on name patterns) run too long to prevent uncontrolled AWS costs.

# How

- Add `rds_instance_age_seconds`
- Document how to add a new metric

# Release plan

- [ ] Merge this PR