### PR TITLE
Avoid memory spike during boot

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
@@ -207,15 +208,23 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Find home directory.
+		// Find home directory
 		home, err := os.UserHomeDir()
 		cobra.CheckErr(err)
 
-		// Search config in home directory or current directory with name ".rds-exporter" (without extension).
-		viper.AddConfigPath(".")
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName("prometheus-rds-exporter")
+		// Search config in home directory or current directory with name "prometheus-rds-exporter.yaml"
+
+		configurationFilename := "prometheus-rds-exporter.yaml"
+		currentPathFilename := configurationFilename
+		homeFilename := filepath.Join(home, configurationFilename)
+
+		if _, err := os.Stat(homeFilename); err == nil {
+			viper.SetConfigFile(homeFilename)
+		}
+
+		if _, err := os.Stat(currentPathFilename); err == nil {
+			viper.SetConfigFile(currentPathFilename)
+		}
 	}
 
 	if err := viper.ReadInConfig(); err == nil {


### PR DESCRIPTION
# Objective

Avoid memory spikes during boot

# Why

Since https://github.com/qonto/prometheus-rds-exporter/commit/a7c42369b5c201547fa8ee61d80a973bc4cc39be, we observe a memory spike when the exporter is starting.

We identified that this memory spike occurred only when `viper.SetConfigName()` match the name of the binary. We'll report the bug to Viper.

# How

- Implement configuration file lookup

# Release plan

- [ ] Merge this PR