### PR TITLE
Add Golang dashboard

### DIFF
--- a/scripts/prometheus/configuration/grafana/entrypoint.sh
+++ b/scripts/prometheus/configuration/grafana/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-DASHBOARD_IDS="19646 19647 19679"
+DASHBOARD_IDS="19646 19647 19679 14061"
 DASHBOARD_PROVISIONNING=/var/tmp/dashboards
 
 download_dashboards() {


### PR DESCRIPTION
# Objective

Add Golang dashboard

# Why

The [Go Runtime Exporter Quickstart and Dashboardby Grafana Labs dashboard](https://grafana.com/grafana/dashboards/14061-go-runtime-metrics/) is helpful to visualize Golang internal metrics.

It was helpful to investigate https://github.com/qonto/prometheus-rds-exporter/pull/41

# How

- Add Go dashboard to local development environment

# Release plan

- [ ] Merge this PR