### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+---
+version: 2
+updates:
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "docker"
+    directory: "/scripts/prometheus"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
# Objective

Enable dependabot

# Why

Dependabot will automatically creates PR when there is new Golang, Docker or Github actions versions.

# How

- Add `.github/dependabot.yml` configuration file

# Release plan

- [ ] Merge this PR
- [ ] Check PR after 1 week