### PR TITLE
Upgrade Grafana & Prometheus

### DIFF
--- a/scripts/prometheus/docker-compose.yml
+++ b/scripts/prometheus/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - 9090:9090
 
   grafana:
-    image: grafana/grafana:10.0.1
+    image: grafana/grafana:10.2.2
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=hackme

--- a/scripts/prometheus/docker-compose.yml
+++ b/scripts/prometheus/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 services:
 
   prometheus:
-    image: prom/prometheus:v2.45.0
+    image: prom/prometheus:v2.48.0
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - ./.prometheus_data:/prometheus


### PR DESCRIPTION
# Objective

Upgrade Grafana & Prometheus to the latest versions

# Why

It was helpful to use the latest versions to investigate the dashboard releasing issue for [Grafana's case 114605](https://grafana.com/orgs/qonto/tickets/114605).

No major changes or breaking changes in Grafana [10.1.0](https://github.com/grafana/grafana/releases/tag/v10.1.0), [10.2.0](https://github.com/grafana/grafana/releases/tag/v10.2.0) or Prometheus [2.46.0](https://github.com/prometheus/prometheus/releases/tag/v2.46.0), [2.47.0](https://github.com/prometheus/prometheus/releases/tag/v2.47.0) and  [2.48.0](https://github.com/prometheus/prometheus/releases/tag/v2.48.0)

# How

- Upgrade `Grafana` to `10.2.2`
- Upgrade `Prometheus` to `2.48.0`

# Release plan

- [ ] Merge this PR