### PR TITLE
Add arn label to rds_instance_info metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It collect key metrics about:
 | rds_free_storage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Free storage on the instance |
 | rds_freeable_memory_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of available random access memory. For MariaDB, MySQL, Oracle, and PostgreSQL DB instances, this metric reports the value of the MemAvailable field of /proc/meminfo |
 | rds_instance_age_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | Time since instance creation |
-| rds_instance_info | `aws_account_id`, `aws_region`, `dbi_resource_id`, `dbidentifier`, `deletion_protection`, `engine`, `engine_version`, `instance_class`, `multi_az`, `performance_insights_enabled`, `pending_maintenance`, `pending_modified_values`, `role`, `source_dbidentifier`, `storage_type`, `ca_certificate_identifier` | RDS instance information |
+| rds_instance_info | `arn`, `aws_account_id`, `aws_region`, `dbi_resource_id`, `dbidentifier`, `deletion_protection`, `engine`, `engine_version`, `instance_class`, `multi_az`, `performance_insights_enabled`, `pending_maintenance`, `pending_modified_values`, `role`, `source_dbidentifier`, `storage_type`, `ca_certificate_identifier` | RDS instance information |
 | rds_instance_log_files_size_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Total of log files on the instance |
 | rds_instance_max_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum IOPS of underlying EC2 instance |
 | rds_instance_max_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum throughput of underlying EC2 instance |

--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -128,7 +128,7 @@ func NewCollector(logger slog.Logger, collectorConfiguration Configuration, awsA
 		),
 		information: prometheus.NewDesc("rds_instance_info",
 			"RDS instance information",
-			[]string{"aws_account_id", "aws_region", "dbidentifier", "dbi_resource_id", "instance_class", "engine", "engine_version", "storage_type", "multi_az", "deletion_protection", "role", "source_dbidentifier", "pending_modified_values", "pending_maintenance", "performance_insights_enabled", "ca_certificate_identifier"}, nil,
+			[]string{"aws_account_id", "aws_region", "dbidentifier", "dbi_resource_id", "instance_class", "engine", "engine_version", "storage_type", "multi_az", "deletion_protection", "role", "source_dbidentifier", "pending_modified_values", "pending_maintenance", "performance_insights_enabled", "ca_certificate_identifier", "arn"}, nil,
 		),
 		age: prometheus.NewDesc("rds_instance_age_seconds",
 			"Time since instance creation",
@@ -451,6 +451,7 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 			instance.PendingMaintenanceAction,
 			strconv.FormatBool(instance.PerformanceInsightsEnabled),
 			instance.CACertificateIdentifier,
+			instance.Arn,
 		)
 		ch <- prometheus.MustNewConstMetric(c.maxAllocatedStorage, prometheus.GaugeValue, float64(instance.MaxAllocatedStorage), c.awsAccountID, c.awsRegion, dbidentifier)
 		ch <- prometheus.MustNewConstMetric(c.maxIops, prometheus.GaugeValue, float64(instance.MaxIops), c.awsAccountID, c.awsRegion, dbidentifier)

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -28,6 +28,7 @@ type Statistics struct {
 }
 
 type RdsInstanceMetrics struct {
+	Arn                              string
 	Engine                           string
 	EngineVersion                    string
 	DBInstanceClass                  string
@@ -269,6 +270,7 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 	}
 
 	metrics := RdsInstanceMetrics{
+		Arn:                        *dbInstance.DBInstanceArn,
 		AllocatedStorage:           converter.GigaBytesToBytes(int64(*dbInstance.AllocatedStorage)),
 		BackupRetentionPeriod:      converter.DaystoSeconds(*dbInstance.BackupRetentionPeriod),
 		DBInstanceClass:            *dbInstance.DBInstanceClass,

--- a/internal/app/rds/rds_test.go
+++ b/internal/app/rds/rds_test.go
@@ -67,13 +67,17 @@ func newRdsCertificateDetails() *aws_rds_types.CertificateDetails {
 }
 
 func newRdsInstance() *aws_rds_types.DBInstance {
+	awsRegion := "eu-west-3"
+	awsAccountID := "123456789012"
 	DBInstanceIdentifier := randomString(10)
+	arn := fmt.Sprintf("arn:aws:rds:%s:%s:db:%s", awsRegion, awsAccountID, DBInstanceIdentifier)
+
 	now := time.Now()
 
 	return &aws_rds_types.DBInstance{
 		AllocatedStorage:           aws.Int32(5),
 		BackupRetentionPeriod:      aws.Int32(7),
-		DBInstanceArn:              aws.String("RandomDBInstanceArn"),
+		DBInstanceArn:              aws.String(arn),
 		DBInstanceClass:            aws.String("t3.large"),
 		DBInstanceIdentifier:       aws.String(DBInstanceIdentifier),
 		DBInstanceStatus:           aws.String("available"),
@@ -110,6 +114,7 @@ func TestGetMetrics(t *testing.T) {
 	assert.Equal(t, rds.InstanceStatusAvailable, m.Status, "Instance is available")
 	assert.Equal(t, "primary", m.Role, "Should be primary node")
 	assert.Equal(t, emptyInt64, m.LogFilesSize, "Log file size mismatch")
+	assert.Equal(t, fmt.Sprintf("arn:aws:rds:eu-west-3:123456789012:db:%s", *rdsInstance.DBInstanceIdentifier), m.Arn, "ARN mismatch")
 
 	assert.Equal(t, converter.GigaBytesToBytes(int64(*rdsInstance.AllocatedStorage)), m.AllocatedStorage, "Allocated storage mismatch")
 	assert.Equal(t, converter.GigaBytesToBytes(int64(*rdsInstance.MaxAllocatedStorage)), m.MaxAllocatedStorage, "Max allocated storage (aka autoscaling) mismatch")


### PR DESCRIPTION
# Objective

Add `arn` label to `rds_instance_info` metric.

# Why

ARN information is the uniq identifier for RDS instance.

This information could be used for alerting

# How

Add `arn` label to `rds_instance_info` metric.

# Release plan

- [ ] Merge this PR