### PR TITLE
Add aws_instance_tags containing AWS tags attached to the instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ It collect key metrics about:
 | rds_instance_max_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum throughput of underlying EC2 instance |
 | rds_instance_memory_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Instance memory |
 | rds_instance_status | `aws_account_id`, `aws_region`, `dbidentifier` | Instance status (1: ok, 0: can't scrap metrics) |
+| rds_instance_tags | `aws_account_id`, `aws_region`, `dbidentifier`, `tag_<AWS_TAG>`... | AWS tags attached to the instance |
 | rds_instance_vcpu_average | `aws_account_id`, `aws_region`, `dbidentifier` | Total vCPU for this isntance class |
 | rds_max_allocated_storage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Upper limit in gibibytes to which Amazon RDS can automatically scale the storage of the DB instance |
 | rds_max_disk_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Max IOPS for the instance |
@@ -152,6 +153,7 @@ Configuration could be defined in [prometheus-rds-exporter.yaml](https://github.
 | aws-assume-role-arn | AWS IAM ARN role to assume to fetch metrics | |
 | aws-assume-role-session | AWS assume role session name | prometheus-rds-exporter |
 | collect-instance-metrics | Collect AWS instances metrics (AWS Cloudwatch API) | true |
+| collect-instance-tags | Collect AWS RDS tags | true |
 | collect-instance-types | Collect AWS instance types information (AWS EC2 API) | true |
 | collect-logs-size | Collect AWS instances logs size (AWS RDS API) | true |
 | collect-maintenances | Collect AWS instances maintenances (AWS RDS API) | true |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ type exporterConfig struct {
 	AWSAssumeRoleSession   string `mapstructure:"aws-assume-role-session"`
 	AWSAssumeRoleArn       string `mapstructure:"aws-assume-role-arn"`
 	CollectInstanceMetrics bool   `mapstructure:"collect-instance-metrics"`
+	CollectInstanceTags    bool   `mapstructure:"collect-instance-tags"`
 	CollectInstanceTypes   bool   `mapstructure:"collect-instance-types"`
 	CollectLogsSize        bool   `mapstructure:"collect-logs-size"`
 	CollectMaintenances    bool   `mapstructure:"collect-maintenances"`
@@ -71,6 +72,7 @@ func run(configuration exporterConfig) {
 	collectorConfiguration := exporter.Configuration{
 		CollectInstanceMetrics: configuration.CollectInstanceMetrics,
 		CollectInstanceTypes:   configuration.CollectInstanceTypes,
+		CollectInstanceTags:    configuration.CollectInstanceTags,
 		CollectLogsSize:        configuration.CollectLogsSize,
 		CollectMaintenances:    configuration.CollectMaintenances,
 		CollectQuotas:          configuration.CollectQuotas,
@@ -118,6 +120,7 @@ func NewRootCommand() (*cobra.Command, error) {
 	cmd.Flags().StringP("listen-address", "", ":9043", "Address to listen on for web interface")
 	cmd.Flags().StringP("aws-assume-role-arn", "", "", "AWS IAM ARN role to assume to fetch metrics")
 	cmd.Flags().StringP("aws-assume-role-session", "", "prometheus-rds-exporter", "AWS assume role session name")
+	cmd.Flags().BoolP("collect-instance-tags", "", true, "Collect AWS RDS tags")
 	cmd.Flags().BoolP("collect-instance-types", "", true, "Collect AWS instance types")
 	cmd.Flags().BoolP("collect-instance-metrics", "", true, "Collect AWS instance metrics")
 	cmd.Flags().BoolP("collect-logs-size", "", true, "Collect AWS instances logs size")
@@ -158,6 +161,11 @@ func NewRootCommand() (*cobra.Command, error) {
 	err = viper.BindPFlag("collect-instance-metrics", cmd.Flags().Lookup("collect-instance-metrics"))
 	if err != nil {
 		return cmd, fmt.Errorf("failed to bind 'collect-instance-metrics' parameter: %w", err)
+	}
+
+	err = viper.BindPFlag("collect-instance-tags", cmd.Flags().Lookup("collect-instance-tags"))
+	if err != nil {
+		return cmd, fmt.Errorf("failed to bind 'collect-instance-tags' parameter: %w", err)
 	}
 
 	err = viper.BindPFlag("collect-instance-types", cmd.Flags().Lookup("collect-instance-types"))

--- a/configs/prometheus-rds-exporter/prometheus-rds-exporter.yaml
+++ b/configs/prometheus-rds-exporter/prometheus-rds-exporter.yaml
@@ -31,6 +31,9 @@
 # Collect AWS instances metrics (AWS Cloudwatch API)
 # collect-instance-metrics: true
 
+# Collect AWS instance tags (AWS RDS API)
+# collect-instance-tags: true
+
 # Collect AWS instance types information (AWS EC2 API)
 # collect-instance-types: true
 

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -53,6 +53,7 @@ type RdsInstanceMetrics struct {
 	CACertificateIdentifier          string
 	CertificateValidTill             *time.Time
 	Age                              *float64
+	Tags                             map[string]string
 }
 
 const (
@@ -269,6 +270,12 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 		certificateValidTill = dbInstance.CertificateDetails.ValidTill
 	}
 
+	tags := make(map[string]string)
+
+	for _, tag := range dbInstance.TagList {
+		tags[*tag.Key] = *tag.Value
+	}
+
 	metrics := RdsInstanceMetrics{
 		Arn:                        *dbInstance.DBInstanceArn,
 		AllocatedStorage:           converter.GigaBytesToBytes(int64(*dbInstance.AllocatedStorage)),
@@ -294,6 +301,7 @@ func (r *RDSFetcher) computeInstanceMetrics(dbInstance aws_rds_types.DBInstance,
 		CACertificateIdentifier:    aws.ToString(dbInstance.CACertificateIdentifier),
 		CertificateValidTill:       certificateValidTill,
 		Age:                        age,
+		Tags:                       tags,
 	}
 
 	return metrics, nil

--- a/internal/app/rds/rds_test.go
+++ b/internal/app/rds/rds_test.go
@@ -94,6 +94,7 @@ func newRdsInstance() *aws_rds_types.DBInstance {
 		CACertificateIdentifier:    aws.String("rds-ca-2019"),
 		CertificateDetails:         newRdsCertificateDetails(),
 		InstanceCreateTime:         &now,
+		TagList:                    []aws_rds_types.Tag{{Key: aws.String("Environment"), Value: aws.String("unittest")}, {Key: aws.String("Team"), Value: aws.String("sre")}},
 	}
 }
 
@@ -130,6 +131,8 @@ func TestGetMetrics(t *testing.T) {
 	assert.Equal(t, *rdsInstance.DBInstanceClass, m.DBInstanceClass, "DBInstanceIdentifier mismatch")
 	assert.Equal(t, *rdsInstance.CACertificateIdentifier, m.CACertificateIdentifier, "CACertificateIdentifier mismatch")
 	assert.Equal(t, *rdsInstance.CertificateDetails.ValidTill, *m.CertificateValidTill, "CertificateValidTill mismatch")
+	assert.Equal(t, "unittest", m.Tags["Environment"], "Environment tag mismatch")
+	assert.Equal(t, "sre", m.Tags["Team"], "Team tag mismatch")
 }
 
 func TestGP2StorageType(t *testing.T) {


### PR DESCRIPTION
# Objective

Add `aws_instance_tags` containing AWS tags attached to the instance.

# Why

We received a feature request to have AWS tags in https://github.com/qonto/prometheus-rds-exporter/issues/37.

Implementation is similar to [yet-another-cloudwatch-exporter](https://github.com/nerdswords/yet-another-cloudwatch-exporter/tree/master#query-examples-without-exportedtagsonmetrics). To limit cardinality, the tags are published in  `rds_instance_tags` metric.

The metrics looks like:

```
rds_instance_tags{aws_account_id="<account_id>",aws_region="<aws_region>",dbidentifier="<rds_identifier>",tag_Tag1="value1",tag_Tag2="value2"} 0
```

So it could be used to join metrics:

```
max by (aws_account_id, aws_region, dbidentifier) (rds_free_storage_bytes{} * 100 / rds_allocated_storage_bytes{}) + on (aws_account_id, aws_region, dbidentifier) group_left(tag_Environment) rds_instance_tags
```

# How

- Add `aws_instance_tags` containing AWS tags attached to the instance.

# Release plan

- [ ] Merge this PR