### PR TITLE
Add support of TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Configuration could be defined in [prometheus-rds-exporter.yaml](https://github.
 | listen-address | Address to listen on for web interface | :9043 |
 | log-format | Log format (`text` or `json`) | json |
 | metrics-path | Path under which to expose metrics | /metrics |
+| tls-cert-path | Path to TLS certificate | |
+| tls-key-path | Path to private key for TLS |
 
 Configuration parameters priorities:
 

--- a/configs/prometheus-rds-exporter/prometheus-rds-exporter.yaml
+++ b/configs/prometheus-rds-exporter/prometheus-rds-exporter.yaml
@@ -5,14 +5,20 @@
 # Enable debug mode
 # debug: false
 
+# Log format (text or json)
+# log-format: json
+
 # Path under which to expose metrics
 # metrics-path: /metrics
 
 # Address to listen on for web interface
 # listen-address: ":9043"
 
-# Log format (text or json)
-# log-format: json
+# Path to TLS certificate
+# tls-cert-path: ""
+
+# Path to private key for TLS
+# tls-key-path: ""
 
 #
 # AWS credentials

--- a/docs/add-configuration-parameter.md
+++ b/docs/add-configuration-parameter.md
@@ -1,0 +1,19 @@
+# Add a configuration parameter
+
+This document explains how to add a configuration parameter in the exporter.
+
+Steps:
+
+1. Define parameter name
+
+1. Implement it
+
+    1. Add a new field in `exporterConfig` structure in `cmd/root.go`
+    1. Add the parameter in flag `cmd.Flags()`
+    1. Add the parameter in viper `viper.BindPFlag()`
+
+1. Add tests
+
+1. Add parameter in the `README.md`
+
+1. Add parameter in YAML default configuration file in `configs/prometheus-rds-exporter/prometheus-rds-exporter.yaml`


### PR DESCRIPTION
# Objective

Add support of TLS

# Why

A Qonto partner has requested that metrics be exposed via HTTPS in https://github.com/qonto/prometheus-rds-exporter/issues/110

# How

- Add `tls-cert-path` and `tls-key-path` parameters

# Release plan

- [ ] Merge this PR