### PR TITLE
Ignore false postive alert for homepage

### DIFF
--- a/internal/infra/http/homepage.go
+++ b/internal/infra/http/homepage.go
@@ -53,5 +53,5 @@ func NewHomePage(version string, metricPath string) (*homeHandler, error) {
 
 func (h homeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "text/html; charset=UTF-8")
-	_, _ = w.Write(h.content)
+	_, _ = w.Write(h.content) // nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter // h.content is rendered by html/template in constructor
 }


### PR DESCRIPTION
# Objective

Ignore false postive alert for homepage

# Why

Semgrep is reporting `go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter` alert:

```
┌────────────────┐
│ 1 Code Finding │
└────────────────┘
                                                   
    internal/infra/http/homepage.go 
    ❯❱ go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
          Detected directly writing or similar in 'http.ResponseWriter.write()'. This bypasses HTML escaping
          that prevents cross-site scripting vulnerabilities. Instead, use the 'html/template' package and  
          render data using 'template.Execute()'.                                                           
          Details: https://sg.run/EkbA                                                                      
                                                                                                            
           56┆ _, _ = w.Write(h.content)
```

We fixed it in https://github.com/qonto/prometheus-rds-exporter/pull/112, but alert is sill reported.

Homepage HTMP content is escaped by `html/template` during [initialisation](https://github.com/qonto/prometheus-rds-exporter/blob/89cf6a56b8a3de67b0f301c92795db9fad02c43e/internal/infra/http/homepage.go#L44-L49).

An alternative might be to use the `template.Execute()` in the HTTP handler , but it will be calculated for each call, which doesn't make sense for this home page.

# How

- Ignore Semgrep alert

# Release plan

- [ ] Merge this PR