### PR TITLE
Support for io2 storage type

### DIFF
--- a/internal/app/rds/helper.go
+++ b/internal/app/rds/helper.go
@@ -99,6 +99,9 @@ func getStorageMetrics(storageType string, allocatedStorage int64, rawIops int64
 		*/
 		theoreticalThroughput := int64(float64(iops) * io2StorageThroughputPerIOPS)
 		storageThroughput = ThresholdValue(io2StorageMinThroughput, theoreticalThroughput, io2StorageMaxThroughput)
+	default:
+		iops = rawIops
+		storageThroughput = rawStorageThroughput
 	}
 
 	return iops, storageThroughput

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -57,35 +57,38 @@ type RdsInstanceMetrics struct {
 }
 
 const (
-	InstanceStatusAvailable                int    = 1
-	InstanceStatusBackingUp                int    = 2
-	InstanceStatusStarting                 int    = 3
-	InstanceStatusModifying                int    = 4
-	InstanceStatusStopped                  int    = 0
-	InstanceStatusUnknown                  int    = -1
-	InstanceStatusStopping                 int    = -2
-	InstanceStatusCreating                 int    = -3
-	InstanceStatusDeleting                 int    = -4
-	NoPendingMaintenanceOperation          string = "no"
-	UnknownMaintenanceOperation            string = "unknown"
-	UnscheduledPendingMaintenanceOperation string = "pending"
-	AutoAppliedPendingMaintenanceOperation string = "auto-applied"
-	ForcedPendingMaintenanceOperation      string = "forced"
-	gp2IOPSMin                             int64  = 100
-	gp2IOPSMax                             int64  = 16000
-	gp2IOPSPerGB                           int64  = 3
-	gp2StorageThroughputVolumeThreshold    int64  = 334
-	gp2StorageThroughputSmallVolume        int64  = 128
-	gp2StorageThroughputLargeVolume        int64  = 250
-	io1HighIOPSThroughputThreshold         int64  = 64000
-	io1HighIOPSThroughputValue             int64  = 1000
-	io1LargeIOPSThroughputThreshold        int64  = 32000
-	io1LargeIOPSThroughputValue            int64  = 16
-	io1MediumIOPSThroughputThreshold       int64  = 2000
-	io1MediumIOPSThroughputValue           int64  = 500
-	io1DefaultIOPSThroughputValue          int64  = 256
-	primaryRole                            string = "primary"
-	replicaRole                            string = "replica"
+	InstanceStatusAvailable                int     = 1
+	InstanceStatusBackingUp                int     = 2
+	InstanceStatusStarting                 int     = 3
+	InstanceStatusModifying                int     = 4
+	InstanceStatusStopped                  int     = 0
+	InstanceStatusUnknown                  int     = -1
+	InstanceStatusStopping                 int     = -2
+	InstanceStatusCreating                 int     = -3
+	InstanceStatusDeleting                 int     = -4
+	NoPendingMaintenanceOperation          string  = "no"
+	UnknownMaintenanceOperation            string  = "unknown"
+	UnscheduledPendingMaintenanceOperation string  = "pending"
+	AutoAppliedPendingMaintenanceOperation string  = "auto-applied"
+	ForcedPendingMaintenanceOperation      string  = "forced"
+	gp2IOPSMin                             int64   = 100
+	gp2IOPSMax                             int64   = 16000
+	gp2IOPSPerGB                           int64   = 3
+	gp2StorageThroughputVolumeThreshold    int64   = 334
+	gp2StorageThroughputSmallVolume        int64   = 128
+	gp2StorageThroughputLargeVolume        int64   = 250
+	io1HighIOPSThroughputThreshold         int64   = 64000
+	io1HighIOPSThroughputValue             int64   = 1000
+	io1LargeIOPSThroughputThreshold        int64   = 32000
+	io1LargeIOPSThroughputValue            int64   = 16
+	io1MediumIOPSThroughputThreshold       int64   = 2000
+	io1MediumIOPSThroughputValue           int64   = 500
+	io1DefaultIOPSThroughputValue          int64   = 256
+	io2StorageMinThroughput                int64   = 256  // 1000 IOPS * 0.256 MiB/s per provisioned IOPS
+	io2StorageMaxThroughput                int64   = 4000 // AWS EBS limit
+	io2StorageThroughputPerIOPS            float64 = 0.256
+	primaryRole                            string  = "primary"
+	replicaRole                            string  = "replica"
 )
 
 var instanceStatuses = map[string]int{


### PR DESCRIPTION
# Objective

Support for io2 storage type

# Why

Amazon RDS now supports io2 Block Express, but Prometheus RDS exporter don't [support it](https://github.com/qonto/prometheus-rds-exporter/blob/ac1a3e5c5f5d786cb3c0f97d83e00faded038d0e/internal/app/rds/helper.go#L41-L93) yet.

Similar to existing storage class types, the information **is not accurate** since we are not evaluating engine database and nitro instance type. **This will be a requirement to release v1 of Prometheus RDS exporter.**

> <img width="783" alt="screenshot 2024-03-12 at 23 25 10" src="https://github.com/qonto/prometheus-rds-exporter/assets/319005/0dffaa9a-6d3d-49af-8d96-f991c50f55f1">
> https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html

> ![io2_bx](https://github.com/qonto/prometheus-rds-exporter/assets/319005/42649988-1e05-4779-b33b-e18ff194d32b)
> https://docs.aws.amazon.com/ebs/latest/userguide/provisioned-iops.html#io2-block-express

> All io2 volumes created after November 21, 2023 are io2 Block Express volumes. io2 volumes created before November 21, 2023 can be converted to io2 Block Express volumes by [modifying the IOPS or size of the volume](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modify-volume.html).
> https://docs.aws.amazon.com/ebs/latest/userguide/provisioned-iops.html#io2-block-express

> The ratio of IOPS to allocated storage (in GiB) must be not more than 1000:1. For DB instances not based on the AWS Nitro System, the ratio is 500:1.
> Maximum IOPS can be provisioned with volumes 256 GiB and larger (1,000 IOPS × 256 GiB = 256,000 IOPS). For DB instances not based on the AWS Nitro System, maximum IOPS are achieved at 512 GiB (500 IOPS x 512 GiB = 256,000 IOPS).
> Throughput scales proportionally up to 0.256 MiB/s per provisioned IOPS. Maximum throughput of 4,000 MiB/s can be achieved at 256,000 IOPS with a 16-KiB I/O size and 16,000 IOPS or higher with a 256-KiB I/O size. For DB instances not based on the AWS Nitro System, maximum throughput of 2,000 MiB/s can be achieved at 128,000 IOPS with a 16-KiB I/O size.
> https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html

# How

- Support io2 storage type
- Add generic rule for unknown storage class type

# Release plan

- [ ] Merge this PR
- [ ] Apply with CI