### PR TITLE
Avoid crash when the RDS instance contains tags with unsupported label characters

### DIFF
--- a/internal/app/exporter/helper.go
+++ b/internal/app/exporter/helper.go
@@ -29,10 +29,9 @@ func getUniqTypeAndIdentifiers(instances map[string]rds.RdsInstanceMetrics) ([]s
 
 func ClearPrometheusLabel(str string) string {
 	// Prometheus metric names may contain ASCII letters, digits, underscores, and colons.
-	// It must match the regex [a-zA-Z_:][a-zA-Z0-9_:]*.
 	// https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
-	InvalidFirstLetterCharacters := regexp.MustCompile(`[^a-zA-Z_:]+`)
-	InvalidCharacters := regexp.MustCompile(`[^a-zA-Z0-9_:]+`)
+	InvalidFirstLetterCharacters := regexp.MustCompile(`[^a-zA-Z]+`)
+	InvalidCharacters := regexp.MustCompile(`[^a-zA-Z0-9_]+`)
 
-	return InvalidFirstLetterCharacters.ReplaceAllString(string(str[0]), "_") + InvalidCharacters.ReplaceAllString(str[1:], "_")
+	return InvalidFirstLetterCharacters.ReplaceAllString(string(str[0]), "") + InvalidCharacters.ReplaceAllString(str[1:], "_")
 }

--- a/internal/app/exporter/helper_test.go
+++ b/internal/app/exporter/helper_test.go
@@ -12,11 +12,11 @@ func TestClearPrometheusLabel(t *testing.T) {
 		label string
 		want  string
 	}{
-		{"tag_services.k8s.aws/controller-version", "tag_services_k8s_aws_controller_version"},
-		{"Unreplaced_LabeL:1", "Unreplaced_LabeL:1"},
-		{"1stInvalidCharacter", "_stInvalidCharacter"},
-		{"_IsValidAValidLabel", "_IsValidAValidLabel"},
-		{":IsValidAValidLabel", ":IsValidAValidLabel"},
+		{"aws:cloudformation:logical_id", "aws_cloudformation_logical_id"},
+		{"services.k8s.aws/controller-version", "services_k8s_aws_controller_version"},
+		{"1InvalidFirstCharacter", "InvalidFirstCharacter"},
+		{":InvalidFirstCharacter", "InvalidFirstCharacter"},
+		{"_InvalidFirstCharacter", "InvalidFirstCharacter"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
# Objective

Avoid crash when the RDS instance contains tags with unsupported label characters

# Why

End-user reported exporter crash when an RDS contains unsupported label characters ( https://github.com/qonto/prometheus-rds-exporter/issues/120).

The `ClearPrometheusLabel()` was not sanitizing correctly the tag.

> Metric names may contain ASCII letters, digits, underscores, and colons. It must match the regex [a-zA-Z_:][a-zA-Z0-9_:]*.
> https://prometheus.io/docs/concepts/data_model/

# How

- Fixed `ClearPrometheusLabel()` function to remove unsupported characters from the Prometheus label

# Release plan

- [ ] Merge this PR
- [ ] Apply with CI