### PR TITLE
Group OpenTelemetry automatic merge requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
         patterns:
           - "github.com/aws/aws-sdk-go-v2"
           - "github.com/aws/aws-sdk-go-v2/*"
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
# Objective

Group OpenTelemetry automatic merge requests

# Why

OpenTelemetry package is frequently updated, which lead dependabot to open many Merge requests.

![screenshot 2024-03-22 at 16 09 46](https://github.com/qonto/prometheus-rds-exporter/assets/319005/d74e9117-874c-4dad-88a0-a1420a6ef69b)

It require more reviews than it should.

# How

- Group OpenTelemetry automatic merge requests

# Release plan

- [ ] Merge this PR
- [ ] Apply with CI