### PR TITLE
Fix crash on ec2 type missing info

### DIFF
--- a/internal/app/ec2/ec2_test.go
+++ b/internal/app/ec2/ec2_test.go
@@ -36,10 +36,21 @@ func TestGetDBInstanceTypeInformation(t *testing.T) {
 			maximumIops:       mock.InstanceT3Small.MaximumIops,
 			maximumThroughput: converter.MegaBytesToBytes(mock.InstanceT3Small.MaximumThroughput),
 		},
+		{
+			instanceType:      "t2.small",
+			vCPU:              mock.InstanceT2Small.Vcpu,
+			memory:            converter.MegaBytesToBytes(mock.InstanceT2Small.Memory),
+			maximumIops:       0, // Don't have Maximum IOPS for non EBS optimized instances
+			maximumThroughput: 0, // Don't have Maximum throughput for non EBS optimized instances
+		},
 	}
 	expectedAPICalls := float64(1)
 
-	instanceTypes := []string{"db.t3.large", "db.t3.small"}
+	instanceTypes := make([]string, len(testCases))
+	for i, instance := range testCases {
+		instanceTypes[i] = instance.instanceType
+	}
+
 	fetcher := ec2.NewFetcher(context, client)
 	result, err := fetcher.GetDBInstanceTypeInformation(instanceTypes)
 

--- a/internal/app/ec2/ec2_test.go
+++ b/internal/app/ec2/ec2_test.go
@@ -15,18 +15,46 @@ func TestGetDBInstanceTypeInformation(t *testing.T) {
 	context := context.TODO()
 	client := mock.EC2Client{}
 
+	testCases := []struct {
+		instanceType      string
+		vCPU              int32
+		memory            int64
+		maximumIops       int32
+		maximumThroughput float64
+	}{
+		{
+			instanceType:      "t3.large",
+			vCPU:              mock.InstanceT3Large.Vcpu,
+			memory:            converter.MegaBytesToBytes(mock.InstanceT3Large.Memory),
+			maximumIops:       mock.InstanceT3Large.MaximumIops,
+			maximumThroughput: converter.MegaBytesToBytes(mock.InstanceT3Large.MaximumThroughput),
+		},
+		{
+			instanceType:      "t3.small",
+			vCPU:              mock.InstanceT3Small.Vcpu,
+			memory:            converter.MegaBytesToBytes(mock.InstanceT3Small.Memory),
+			maximumIops:       mock.InstanceT3Small.MaximumIops,
+			maximumThroughput: converter.MegaBytesToBytes(mock.InstanceT3Small.MaximumThroughput),
+		},
+	}
+	expectedAPICalls := float64(1)
+
 	instanceTypes := []string{"db.t3.large", "db.t3.small"}
 	fetcher := ec2.NewFetcher(context, client)
 	result, err := fetcher.GetDBInstanceTypeInformation(instanceTypes)
 
 	require.NoError(t, err, "GetDBInstanceTypeInformation must succeed")
-	assert.Equal(t, mock.InstanceT3Large.Vcpu, result.Instances["db.t3.large"].Vcpu, "vCPU don't match")
-	assert.Equal(t, converter.MegaBytesToBytes(mock.InstanceT3Large.Memory), result.Instances["db.t3.large"].Memory, "Memory don't match")
-	assert.Equal(t, mock.InstanceT3Large.MaximumIops, result.Instances["db.t3.large"].MaximumIops, "MaximumThroughput don't match")
-	assert.Equal(t, converter.MegaBytesToBytes(mock.InstanceT3Large.MaximumThroughput), result.Instances["db.t3.large"].MaximumThroughput, "MaximumThroughput don't match")
+	assert.Equal(t, expectedAPICalls, fetcher.GetStatistics().EC2ApiCall, "EC2 API calls don't match")
 
-	assert.Equal(t, mock.InstanceT3Small.Vcpu, result.Instances["db.t3.small"].Vcpu, "vCPU don't match")
-	assert.Equal(t, converter.MegaBytesToBytes(mock.InstanceT3Small.Memory), result.Instances["db.t3.small"].Memory, "Memory don't match")
+	for _, tc := range testCases {
+		testName := "Test " + tc.instanceType
+		t.Run(testName, func(t *testing.T) {
+			instance := result.Instances["db."+tc.instanceType]
 
-	assert.Equal(t, float64(1), fetcher.GetStatistics().EC2ApiCall, "EC2 API call don't match")
+			assert.Equal(t, tc.vCPU, instance.Vcpu, "vCPU don't match")
+			assert.Equal(t, tc.memory, instance.Memory, "Memory don't match")
+			assert.Equal(t, tc.maximumIops, instance.MaximumIops, "Maximum IOPS don't match")
+			assert.Equal(t, tc.maximumThroughput, instance.MaximumThroughput, "Maximum throughput don't match")
+		})
+	}
 }

--- a/internal/app/ec2/mock/ec2.go
+++ b/internal/app/ec2/mock/ec2.go
@@ -25,6 +25,12 @@ var InstanceT3Small = ec2.EC2InstanceMetrics{
 	Vcpu:              2,
 }
 
+//nolint:golint,gomnd
+var InstanceT2Small = ec2.EC2InstanceMetrics{
+	Memory: 2,
+	Vcpu:   1,
+}
+
 type EC2Client struct{}
 
 func (m EC2Client) DescribeInstanceTypes(ctx context.Context, input *aws_ec2.DescribeInstanceTypesInput, optFns ...func(*aws_ec2.Options)) (*aws_ec2.DescribeInstanceTypesOutput, error) {
@@ -52,6 +58,12 @@ func (m EC2Client) DescribeInstanceTypes(ctx context.Context, input *aws_ec2.Des
 					MaximumIops:             &InstanceT3Small.MaximumIops,
 					MaximumThroughputInMBps: &InstanceT3Small.MaximumThroughput,
 				}},
+			})
+		case "t2.small":
+			instances = append(instances, aws_ec2_types.InstanceTypeInfo{
+				InstanceType: instanceType,
+				VCpuInfo:     &aws_ec2_types.VCpuInfo{DefaultVCpus: &InstanceT2Small.Vcpu},
+				MemoryInfo:   &aws_ec2_types.MemoryInfo{SizeInMiB: &InstanceT2Small.Memory},
 			})
 		}
 	}


### PR DESCRIPTION
# Objective

Fix crash when polling EC2 instance without EBS optimized storage

# Why

The https://github.com/qonto/prometheus-rds-exporter/issues/141 bug was partially fixed by https://github.com/qonto/prometheus-rds-exporter/pull/152.

The `EbsInfo.EbsOptimizedInfo` could be a nil pointer as well as `EbsInfo` when an EC2 instance don't have EBS optimization information. So we need to check this value before using it.

# How

- Refact EC2 tests to use table test approach (Golang standard)
- Add tests for EC2 instance without EBS optimization (t2.small)
- Check nil value for `VCpuInfo`, `MemoryInfo`, `EbsInfo` and `EbsInfo.EbsOptimizedInfo` nil pointer

# Release plan

- [ ] Merge this PR
- [ ] Apply with CI