### PR TITLE
Disable automatic dashboard deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ It collects key metrics about:
 ## Dashboards
 
 > [!TIP]
-> Grafana dashboards are deployed by default as [GrafanaDashboard CRD](https://grafana.github.io/grafana-operator/docs/dashboards/) when Prometheus RDS exporter is deployed with Helm. If you deployed [Grafana operator](https://grafana.github.io/grafana-operator/) in your Kubernetes cluster, dashboards will be automatically imported and **maintained up-to-date**.
+> If you deploy [Grafana operator](https://grafana.github.io/grafana-operator/) in your Kubernetes cluster, dashboards could be automatically deployed and **maintained up-to-date**.
+> Set `dashboards.enabled: true` in your Helm deployment to deploy dashboards as [GrafanaDashboard CRD](https://grafana.github.io/grafana-operator/docs/dashboards/)
 
 <details>
   <summary>Why are we recommending Grafana operator?</summary>

--- a/configs/helm/tests/grafanadashboard_test.yaml
+++ b/configs/helm/tests/grafanadashboard_test.yaml
@@ -4,7 +4,13 @@ suite: grafana dashboard tests
 templates:
   - grafanadashboard.yaml
 tests:
+  - it: disable Grafana dashboards by default
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: render default Grafana dashboards
+    values:
+      - ./values/with_grafanadashboards.yaml
     asserts:
       - isKind:
           of: GrafanaDashboard
@@ -33,7 +39,7 @@ tests:
           value: grafana
   - it: render custom Grafana dashboards settings
     values:
-      - ./values/with_grafanadashboards.yaml
+      - ./values/with_grafanadashboards_custom.yaml
     asserts:
       - equal:
           path: spec.resyncPeriod
@@ -44,9 +50,3 @@ tests:
       - equal:
           path: spec.instanceSelector.matchLabels.dashboards
           value: my-grafana
-  - it: disable Grafana dashboards
-    values:
-      - ./values/without_grafanadashboards.yaml
-    asserts:
-      - hasDocuments:
-          count: 0

--- a/configs/helm/tests/values/with_grafanadashboards.yaml
+++ b/configs/helm/tests/values/with_grafanadashboards.yaml
@@ -1,5 +1,3 @@
 ---
 dashboards:
-  resyncPeriod: 1m
-  instanceSelector: my-grafana
-  folderName: dmf
+  enabled: true

--- a/configs/helm/tests/values/with_grafanadashboards_custom.yaml
+++ b/configs/helm/tests/values/with_grafanadashboards_custom.yaml
@@ -1,0 +1,6 @@
+---
+dashboards:
+  enabled: true
+  resyncPeriod: 1m
+  instanceSelector: my-grafana
+  folderName: dmf

--- a/configs/helm/tests/values/without_grafanadashboards.yaml
+++ b/configs/helm/tests/values/without_grafanadashboards.yaml
@@ -1,3 +1,0 @@
----
-dashboards:
-  enabled: false

--- a/configs/helm/values.yaml
+++ b/configs/helm/values.yaml
@@ -86,7 +86,7 @@ tolerations: []
 affinity: {}
 
 dashboards:
-  enabled: true  # enabled GrafanaDashboard CRD import
+  enabled: false  # enabled GrafanaDashboard CRD import
   resyncPeriod: 24h  # how often the dashboard is refreshed
   instanceSelector: grafana  # selects Grafana for import
   folderName:  # folder assignment for dashboard


### PR DESCRIPTION
# Objective

Disable automatic dashboard deployment

# Why

Dashboards deployment should be opt-in because deployment could be blocked if Grafana CRD does not exist.

# How

- Set `enabled: true`

# Release plan

- [ ] Merge this PR
- [ ] Apply with CI