### PR TITLE
Fix: Properly pass logger in ServiceQuota Fetcher

### DIFF
--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -477,7 +477,7 @@ func (c *rdsCollector) getQuotasMetrics(client servicequotas.ServiceQuotasClient
 
 	c.logger.Debug("fetch quotas")
 
-	fetcher := servicequotas.NewFetcher(ctx, client)
+	fetcher := servicequotas.NewFetcher(ctx, client, c.logger)
 
 	metrics, err := fetcher.GetRDSQuotas()
 	if err != nil {

--- a/internal/app/servicequotas/mock/servicequotas.go
+++ b/internal/app/servicequotas/mock/servicequotas.go
@@ -37,3 +37,29 @@ func (m ServiceQuotasClient) GetServiceQuota(context context.Context, input *aws
 
 	return &aws_servicequotas.GetServiceQuotaOutput{Quota: quota}, nil
 }
+
+type ServiceQuotasClientQuotaError struct {
+	ExpectedErrorQotaCode    string
+	ExpectedErrorQuotaOutput *aws_servicequotas.GetServiceQuotaOutput
+}
+
+func (m ServiceQuotasClientQuotaError) GetServiceQuota(context context.Context, input *aws_servicequotas.GetServiceQuotaInput, optFns ...func(*aws_servicequotas.Options)) (*aws_servicequotas.GetServiceQuotaOutput, error) {
+	value := UnknownServiceQuota
+
+	if *input.ServiceCode == servicequotas.RDSServiceCode {
+		switch *input.QuotaCode {
+		case m.ExpectedErrorQotaCode:
+			return m.ExpectedErrorQuotaOutput, nil
+		case servicequotas.DBinstancesQuotacode:
+			value = DBinstancesQuota
+		case servicequotas.TotalStorageQuotaCode:
+			value = TotalStorage
+		case servicequotas.ManualDBInstanceSnapshotsQuotaCode:
+			value = ManualDBInstanceSnapshots
+		}
+	}
+
+	quota := &aws_servicequotas_types.ServiceQuota{Value: &value}
+
+	return &aws_servicequotas.GetServiceQuotaOutput{Quota: quota}, nil
+}

--- a/internal/app/servicequotas/servicequotas.go
+++ b/internal/app/servicequotas/servicequotas.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	aws_servicequotas "github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/qonto/prometheus-rds-exporter/internal/app/trace"
 	converter "github.com/qonto/prometheus-rds-exporter/internal/app/unit"
@@ -87,7 +88,7 @@ func (s *serviceQuotaFetcher) getQuota(serviceCode string, quotaCode string) (fl
 
 	// AWS response payload could contains errors (eg. missing permission)
 	if result.Quota.ErrorReason != nil {
-		s.logger.Error("AWS quota error: ", "errorCode", result.Quota.ErrorReason.ErrorCode, "message", *result.Quota.ErrorReason.ErrorMessage)
+		s.logger.Error("AWS quota error: ", "errorCode", result.Quota.ErrorReason.ErrorCode, "message", aws.ToString(result.Quota.ErrorReason.ErrorMessage))
 		span.SetStatus(codes.Error, "failed to fetch quota")
 		span.RecordError(errQuotaError)
 

--- a/internal/app/servicequotas/servicequotas.go
+++ b/internal/app/servicequotas/servicequotas.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	aws_servicequotas "github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/qonto/prometheus-rds-exporter/internal/app/trace"
 	converter "github.com/qonto/prometheus-rds-exporter/internal/app/unit"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
-	"golang.org/x/exp/slog"
 )
 
 var (
@@ -44,10 +44,11 @@ type ServiceQuotasClient interface {
 	GetServiceQuota(ctx context.Context, input *aws_servicequotas.GetServiceQuotaInput, optFns ...func(*aws_servicequotas.Options)) (*aws_servicequotas.GetServiceQuotaOutput, error)
 }
 
-func NewFetcher(ctx context.Context, client ServiceQuotasClient) *serviceQuotaFetcher {
+func NewFetcher(ctx context.Context, client ServiceQuotasClient, logger slog.Logger) *serviceQuotaFetcher {
 	return &serviceQuotaFetcher{
 		ctx:    ctx,
 		client: client,
+		logger: &logger,
 	}
 }
 

--- a/internal/app/servicequotas/servicequotas_test.go
+++ b/internal/app/servicequotas/servicequotas_test.go
@@ -2,8 +2,11 @@ package servicequotas_test
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
+	aws_servicequotas "github.com/aws/aws-sdk-go-v2/service/servicequotas"
+	"github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
 	"github.com/qonto/prometheus-rds-exporter/internal/app/servicequotas"
 	mock "github.com/qonto/prometheus-rds-exporter/internal/app/servicequotas/mock"
 	converter "github.com/qonto/prometheus-rds-exporter/internal/app/unit"
@@ -13,12 +16,32 @@ import (
 )
 
 func TestGetRDSQuotas(t *testing.T) {
-	context := context.TODO()
-	client := mock.ServiceQuotasClient{}
+	logger := slog.Default()
+	t.Run("GetRDSQuotasHappyPath", func(t *testing.T) {
+		context := context.TODO()
+		client := mock.ServiceQuotasClient{}
 
-	result, err := servicequotas.NewFetcher(context, client).GetRDSQuotas()
-	require.NoError(t, err, "GetRDSQuotas must succeed")
-	assert.Equal(t, mock.DBinstancesQuota, result.DBinstances, "DbInstance quota is incorrect")
-	assert.Equal(t, converter.GigaBytesToBytes(mock.TotalStorage), result.TotalStorage, "Total storage quota is incorrect")
-	assert.Equal(t, mock.ManualDBInstanceSnapshots, result.ManualDBInstanceSnapshots, "Manual db instance snapshot quota is incorrect")
+		result, err := servicequotas.NewFetcher(context, client, *logger).GetRDSQuotas()
+		require.NoError(t, err, "GetRDSQuotas must succeed")
+		assert.Equal(t, mock.DBinstancesQuota, result.DBinstances, "DbInstance quota is incorrect")
+		assert.Equal(t, converter.GigaBytesToBytes(mock.TotalStorage), result.TotalStorage, "Total storage quota is incorrect")
+		assert.Equal(t, mock.ManualDBInstanceSnapshots, result.ManualDBInstanceSnapshots, "Manual db instance snapshot quota is incorrect")
+	})
+
+	t.Run("GetRDSQuotasErrorFetchingQuotaNilErrorMessage", func(t *testing.T) {
+		context := context.TODO()
+		client := mock.ServiceQuotasClientQuotaError{
+			ExpectedErrorQotaCode: servicequotas.DBinstancesQuotacode,
+			ExpectedErrorQuotaOutput: &aws_servicequotas.GetServiceQuotaOutput{
+				Quota: &types.ServiceQuota{
+					ErrorReason: &types.ErrorReason{
+						ErrorCode: types.ErrorCodeServiceQuotaNotAvailableError,
+					},
+				},
+			},
+		}
+
+		_, err := servicequotas.NewFetcher(context, client, *logger).GetRDSQuotas()
+		require.EqualError(t, err, "can't fetch DBinstance quota: AWS return error for this quota")
+	})
 }


### PR DESCRIPTION
## Description

This PR is fixing the bug faced in this issue https://github.com/qonto/prometheus-rds-exporter/issues/205

## Why

Until now if we failed to fetch some quota on AWS we ended up trying to log an error while the logger was `nil` which results in the application panicking

## How

* Properly passing the logger to the `serviceQuotaFetch`
* Adding a aws.ToString to dereference string pointer to be safer
* Adding a new test case to pass in the problematic branch