### PR TITLE
fix: Update test to pass linter rules

### DIFF
--- a/internal/app/servicequotas/servicequotas_test.go
+++ b/internal/app/servicequotas/servicequotas_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestGetRDSQuotas(t *testing.T) {
 	logger := slog.Default()
+
 	t.Run("GetRDSQuotasHappyPath", func(t *testing.T) {
 		context := context.TODO()
 		client := mock.ServiceQuotasClient{}


### PR DESCRIPTION
## Description

This PR is adding a new line to pass the `wsl` rule of the linter.

## Why 

This previous PR https://github.com/qonto/prometheus-rds-exporter/pull/209 broke the linter job

I've confirmed is working locally running:
```
golangci-lint run
```

Before and after the changes