### PR TITLE
Fix missing set serviceAccount.name when deployed in EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,8 @@ See the [Development environment](#development-environment) to start the Prometh
     --version ${PROMETHEUS_RDS_EXPORTER_VERSION} \
     --install \
     --namespace ${KUBERNETES_NAMESPACE} \
-    --set serviceAccount.annotations."eks\.amazonaws\.com\/role-arn"="${SERVICE_ACCOUNT_ANNOTATION}"
+    --set serviceAccount.annotations."eks\.amazonaws\.com\/role-arn"="${SERVICE_ACCOUNT_ANNOTATION}" \
+    --set serviceAccount.name="${IAM_ROLE_NAME}"
     ```
 
 1. Option. Customize Prometheus exporter settings
@@ -379,6 +380,7 @@ See the [Development environment](#development-environment) to start the Prometh
     --install \
     --namespace ${KUBERNETES_NAMESPACE} \
     --set serviceAccount.annotations."eks\.amazonaws\.com\/role-arn"="${SERVICE_ACCOUNT_ANNOTATION}" \
+    --set serviceAccount.name="${IAM_ROLE_NAME}" \
     --values values.yaml
     ```
 


### PR DESCRIPTION
When `serviceAccount.name` is not specified, the automatically generated `serviceAccount.name` will be inconsistent with the previously created role name, resulting in the following error:

```
can't fetch information about current session: operation error STS: GetCallerIdentity, get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, https response error StatusCode: 403
```