### PR TITLE
chore: Added more important instance statuses

### DIFF
--- a/configs/grafana/common.libsonnet
+++ b/configs/grafana/common.libsonnet
@@ -12,6 +12,7 @@ local options = link.dashboards.options;
     transparent: 'transparent',
     default: 'white',
     ok: 'green',
+    info: 'blue',
     notice: 'yellow',
     warning: 'orange',
     danger: 'red',

--- a/configs/grafana/panels/instance.libsonnet
+++ b/configs/grafana/panels/instance.libsonnet
@@ -131,7 +131,7 @@ local colors = common.colors;
           '1': { index: 9, color: colors.ok, text: 'Available' },
           '2': { index: 10, color: colors.notice, text: 'Backing-up' },
           '3': { index: 11, color: colors.ok, text: 'Starting' },
-          '4': { index: 12, color: colors.transparent, text: 'Modifying' },
+          '4': { index: 12, color: colors.info, text: 'Modifying' },
         }),
       ]),
   },
@@ -476,7 +476,7 @@ local colors = common.colors;
           '1': { index: 9, color: colors.ok, text: 'Available' },
           '2': { index: 10, color: colors.notice, text: 'Backing-up' },
           '3': { index: 11, color: colors.ok, text: 'Starting' },
-          '4': { index: 12, color: colors.transparent, text: 'Modifying' },
+          '4': { index: 12, color: colors.info, text: 'Modifying' },
         }),
       ])
       + standardOptions.withMin(null)

--- a/configs/grafana/panels/instance.libsonnet
+++ b/configs/grafana/panels/instance.libsonnet
@@ -119,10 +119,19 @@ local colors = common.colors;
       + standardOptions.withMappings([
         standardOptions.mapping.ValueMap.withType('value')
         + standardOptions.mapping.ValueMap.withOptions({
-          '-1': { index: 0, color: 'purple', text: 'Unknown' },
-          '0': { index: 1, color: colors.danger, text: 'Stopped' },
-          '1': { index: 2, color: colors.ok, text: 'Available' },
-          '2': { index: 3, color: colors.notice, text: 'Backing-up' },
+          '-8': { index: 0, color: colors.info, text: 'Upgrading' },
+          '-7': { index: 1, color: colors.danger, text: 'Storage-full' },
+          '-6': { index: 2, color: colors.danger, text: 'Failed' },
+          '-5': { index: 3, color: colors.warning, text: 'Rebooting' },
+          '-4': { index: 4, color: colors.danger, text: 'Deleting' },
+          '-3': { index: 5, color: colors.notice, text: 'Creating' },
+          '-2': { index: 6, color: colors.notice, text: 'Stopping' },
+          '-1': { index: 7, color: 'purple', text: 'Unknown' },
+          '0': { index: 8, color: colors.danger, text: 'Stopped' },
+          '1': { index: 9, color: colors.ok, text: 'Available' },
+          '2': { index: 10, color: colors.notice, text: 'Backing-up' },
+          '3': { index: 11, color: colors.ok, text: 'Starting' },
+          '4': { index: 12, color: colors.transparent, text: 'Modifying' },
         }),
       ]),
   },
@@ -386,13 +395,13 @@ local colors = common.colors;
         fieldOverride.byName.new('Replication slots')
         + standardOptions.override.byType.withPropertiesFromOptions(
           color.withMode('fixed')
-          + color.withFixedColor('blue')
+          + color.withFixedColor(colors.info)
           + custom.stacking.withMode('normal')
         ),
         fieldOverride.byName.new('Other')
         + standardOptions.override.byType.withPropertiesFromOptions(
           color.withMode('fixed')
-          + color.withFixedColor('orange')
+          + color.withFixedColor(colors.warning)
           + custom.stacking.withMode('normal')
         ),
         fieldOverride.byName.new('Used')
@@ -455,12 +464,19 @@ local colors = common.colors;
       + standardOptions.withMappings([
         standardOptions.mapping.ValueMap.withType('value')
         + standardOptions.mapping.ValueMap.withOptions({
-          '-2': { index: -2, color: colors.warning, text: 'Stopping' },
-          '-1': { index: -1, color: colors.notice, text: 'Unknown' },
-          '0': { index: -1, color: colors.warning, text: 'Stopped' },
-          '1': { index: -1, color: colors.ok, text: 'Available' },
-          '2': { index: -1, color: colors.notice, text: 'Backing-up' },
-          '3': { index: -1, color: colors.warning, text: 'Starting' },
+          '-8': { index: 0, color: colors.info, text: 'Upgrading' },
+          '-7': { index: 1, color: colors.danger, text: 'Storage-full' },
+          '-6': { index: 2, color: colors.danger, text: 'Failed' },
+          '-5': { index: 3, color: colors.warning, text: 'Rebooting' },
+          '-4': { index: 4, color: colors.danger, text: 'Deleting' },
+          '-3': { index: 5, color: colors.notice, text: 'Creating' },
+          '-2': { index: 6, color: colors.notice, text: 'Stopping' },
+          '-1': { index: 7, color: 'purple', text: 'Unknown' },
+          '0': { index: 8, color: colors.danger, text: 'Stopped' },
+          '1': { index: 9, color: colors.ok, text: 'Available' },
+          '2': { index: 10, color: colors.notice, text: 'Backing-up' },
+          '3': { index: 11, color: colors.ok, text: 'Starting' },
+          '4': { index: 12, color: colors.transparent, text: 'Modifying' },
         }),
       ])
       + standardOptions.withMin(null)

--- a/internal/app/rds/rds.go
+++ b/internal/app/rds/rds.go
@@ -69,6 +69,10 @@ const (
 	InstanceStatusStopping                 int     = -2
 	InstanceStatusCreating                 int     = -3
 	InstanceStatusDeleting                 int     = -4
+	InstanceStatusRebooting                int     = -5
+	InstanceStatusFailed                   int     = -6
+	InstanceStatusStorageFull              int     = -7
+	InstanceStatusUpgrading                int     = -8
 	NoPendingMaintenanceOperation          string  = "no"
 	UnknownMaintenanceOperation            string  = "unknown"
 	UnscheduledPendingMaintenanceOperation string  = "pending"
@@ -97,15 +101,19 @@ const (
 var tracer = otel.Tracer("github/qonto/prometheus-rds-exporter/internal/app/rds")
 
 var instanceStatuses = map[string]int{
-	"available":  InstanceStatusAvailable,
-	"backing-up": InstanceStatusBackingUp,
-	"creating":   InstanceStatusCreating,
-	"deleting":   InstanceStatusDeleting,
-	"modifying":  InstanceStatusModifying,
-	"starting":   InstanceStatusStarting,
-	"stopped":    InstanceStatusStopped,
-	"stopping":   InstanceStatusStopping,
-	"unknown":    InstanceStatusUnknown,
+	"available":    InstanceStatusAvailable,
+	"backing-up":   InstanceStatusBackingUp,
+	"creating":     InstanceStatusCreating,
+	"deleting":     InstanceStatusDeleting,
+	"failed":       InstanceStatusFailed,
+	"modifying":    InstanceStatusModifying,
+	"rebooting":    InstanceStatusRebooting,
+	"starting":     InstanceStatusStarting,
+	"stopped":      InstanceStatusStopped,
+	"storage-full": InstanceStatusStorageFull,
+	"stopping":     InstanceStatusStopping,
+	"unknown":      InstanceStatusUnknown,
+	"upgrading":    InstanceStatusUpgrading,
 }
 
 type RDSClient interface {

--- a/internal/app/rds/rds_test.go
+++ b/internal/app/rds/rds_test.go
@@ -262,11 +262,15 @@ func TestGetDBInstanceStatusCode(t *testing.T) {
 		{input: "backing-up", want: rds.InstanceStatusBackingUp},
 		{input: "creating", want: rds.InstanceStatusCreating},
 		{input: "deleting", want: rds.InstanceStatusDeleting},
+		{input: "failed", want: rds.InstanceStatusFailed},
 		{input: "future", want: rds.InstanceStatusUnknown},
 		{input: "modifying", want: rds.InstanceStatusModifying},
 		{input: "stopped", want: rds.InstanceStatusStopped},
 		{input: "stopping", want: rds.InstanceStatusStopping},
+		{input: "storage-full", want: rds.InstanceStatusStorageFull},
+		{input: "rebooting", want: rds.InstanceStatusRebooting},
 		{input: "unknown", want: rds.InstanceStatusUnknown},
+		{input: "upgrading", want: rds.InstanceStatusUpgrading},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Some important RDS statuses were missing (by default they always go as `unknown`), adding these is necessary to be able to have better observability, prompt reaction, and the possibility to have custom metrics alerts.

Added:
- `failed`: when the DB instance has failed and AWS can't recover it
- `storage-full`: when the DB instance has reached its storage capacity allocation
- `rebooting`: when the DB instance is performing a reboot
- `upgrading`: when the DB engine or OS version is being upgraded

It is also nice to have since any of these statuses may be an indication of a disruption to the RDS instance.