### PR TITLE
fix: don't expose metrics with no values

### DIFF
--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -582,9 +582,15 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 			instance.CACertificateIdentifier,
 			instance.Arn,
 		)
-		ch <- prometheus.MustNewConstMetric(c.maxAllocatedStorage, prometheus.GaugeValue, float64(instance.MaxAllocatedStorage), c.awsAccountID, c.awsRegion, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.allocatedDiskIOPS, prometheus.GaugeValue, float64(instance.MaxIops), c.awsAccountID, c.awsRegion, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.allocatedDiskThroughput, prometheus.GaugeValue, float64(instance.StorageThroughput), c.awsAccountID, c.awsRegion, dbidentifier)
+		if instance.MaxAllocatedStorage > 0 {
+			ch <- prometheus.MustNewConstMetric(c.maxAllocatedStorage, prometheus.GaugeValue, float64(instance.MaxAllocatedStorage), c.awsAccountID, c.awsRegion, dbidentifier)
+		}
+		if instance.MaxIops > 0 {
+			ch <- prometheus.MustNewConstMetric(c.allocatedDiskIOPS, prometheus.GaugeValue, float64(instance.MaxIops), c.awsAccountID, c.awsRegion, dbidentifier)
+		}
+		if instance.StorageThroughput > 0 {
+			ch <- prometheus.MustNewConstMetric(c.allocatedDiskThroughput, prometheus.GaugeValue, float64(instance.StorageThroughput), c.awsAccountID, c.awsRegion, dbidentifier)
+		}
 		ch <- prometheus.MustNewConstMetric(c.status, prometheus.GaugeValue, float64(instance.Status), c.awsAccountID, c.awsRegion, dbidentifier)
 		ch <- prometheus.MustNewConstMetric(c.backupRetentionPeriod, prometheus.GaugeValue, float64(instance.BackupRetentionPeriod), c.awsAccountID, c.awsRegion, dbidentifier)
 
@@ -597,8 +603,12 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 			storageThroughput = min(float64(instance.StorageThroughput), ec2Metrics.BaselineThroughput)
 		}
 
-		ch <- prometheus.MustNewConstMetric(c.maxIops, prometheus.GaugeValue, float64(maxIops), c.awsAccountID, c.awsRegion, dbidentifier)
-		ch <- prometheus.MustNewConstMetric(c.storageThroughput, prometheus.GaugeValue, storageThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
+		if maxIops > 0 {
+			ch <- prometheus.MustNewConstMetric(c.maxIops, prometheus.GaugeValue, float64(maxIops), c.awsAccountID, c.awsRegion, dbidentifier)
+		}
+		if storageThroughput > 0 {
+			ch <- prometheus.MustNewConstMetric(c.storageThroughput, prometheus.GaugeValue, storageThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
+		}
 
 		if c.configuration.CollectInstanceTags {
 			names, values := c.getInstanceTagLabels(dbidentifier, instance)


### PR DESCRIPTION
For aurora instances some expected instance values are missing. This makes some alert rules break with descriptions like "uses +Inf% of its disk IOPS" from https://github.com/qonto/database-monitoring-framework/blob/06895041d0c918915c24d4b30ed52049051d002c/charts/prometheus-rds-alerts/values.yaml#L125

This PR prevents the metrics I've identified as problematic from being exported when they have not been set.