### PR TITLE
Support deployment in non Grafana namespace

### DIFF
--- a/configs/helm/templates/grafanadashboard.yaml
+++ b/configs/helm/templates/grafanadashboard.yaml
@@ -8,6 +8,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ $path | base | trimSuffix ".json" }}
 spec:
+  allowCrossNamespaceImport: {{ .Values.dashboards.allowCrossNamespaceImport }}
   resyncPeriod: {{ .Values.dashboards.resyncPeriod }}
   folder: {{ .Values.dashboards.folderName }}
   instanceSelector:

--- a/configs/helm/tests/grafanadashboard_test.yaml
+++ b/configs/helm/tests/grafanadashboard_test.yaml
@@ -29,6 +29,9 @@ tests:
           path: metadata.name
           value: rds-instances
       - equal:
+          path: spec.allowCrossNamespaceImport
+          value: true
+      - equal:
           path: spec.resyncPeriod
           value: 24h
       - equal:
@@ -41,6 +44,9 @@ tests:
     values:
       - ./values/with_grafanadashboards_custom.yaml
     asserts:
+      - equal:
+          path: spec.allowCrossNamespaceImport
+          value: false
       - equal:
           path: spec.resyncPeriod
           value: 1m

--- a/configs/helm/tests/values/with_grafanadashboards_custom.yaml
+++ b/configs/helm/tests/values/with_grafanadashboards_custom.yaml
@@ -1,6 +1,7 @@
 ---
 dashboards:
   enabled: true
+  allowCrossNamespaceImport: false  # Disable cross namespace dashboard import
   resyncPeriod: 1m
   instanceSelector: my-grafana
   folderName: dmf

--- a/configs/helm/values.yaml
+++ b/configs/helm/values.yaml
@@ -92,6 +92,7 @@ affinity: {}
 
 dashboards:
   enabled: false  # enabled GrafanaDashboard CRD import
+  allowCrossNamespaceImport: True  # allow cross-namespace dashboard import. So Grafana and dashboards custom resource can be in different namespaces
   resyncPeriod: 24h  # how often the dashboard is refreshed
   instanceSelector: grafana  # selects Grafana for import
   folderName:  # folder assignment for dashboard

--- a/configs/helm/values.yaml
+++ b/configs/helm/values.yaml
@@ -92,7 +92,7 @@ affinity: {}
 
 dashboards:
   enabled: false  # enabled GrafanaDashboard CRD import
-  allowCrossNamespaceImport: True  # allow cross-namespace dashboard import. So Grafana and dashboards custom resource can be in different namespaces
+  allowCrossNamespaceImport: true  # define if Grafana operator can loads dashboards when stored in a different namespace
   resyncPeriod: 24h  # how often the dashboard is refreshed
   instanceSelector: grafana  # selects Grafana for import
   folderName:  # folder assignment for dashboard


### PR DESCRIPTION
# Objective

Support deployment in non Grafana namespace

# Why

The Helm chart leverages the `GrafanaDashboard` CRD to deploy Grafana dashboards out of the box. However, in the current configuration, dashboards can only be imported into Grafana when the Prometheus RDS exporter and Grafana operator are deployed in the same namespace.

The [spec.allowCrossNamespaceImport](https://grafana.github.io/grafana-operator/docs/overview/#cross-namespace-grafana-instances) parameter in `GrafanaDashboard` CRD can be used to enabled cross-namespace dashboard import.

In fact, this should be the default value to support large variety of Kubernetes deployment, but be configurable for environment that requires strict isolation.

In this PR I'm adding the `allowCrossNamespaceImport`, with a default value to `true`

# How

- Add `dashboards.allowCrossNamespaceImport` Helm chart value, set to `true` by default
- Add unit tests to check the default value and custom value

# Release plan

- [ ] Merge this PR
- [ ] Release new minor version