### PR TITLE
feat: add support for including RDS instance tags as labels in all metrics

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ type exporterConfig struct {
 	CollectMaintenances    bool                `koanf:"collect-maintenances"`
 	CollectQuotas          bool                `koanf:"collect-quotas"`
 	CollectUsages          bool                `koanf:"collect-usages"`
+	IncludeTagsInMetrics   bool                `koanf:"include-tags-in-metrics"`
 	OTELTracesEnabled      bool                `koanf:"enable-otel-traces"`
 	TagSelections          map[string][]string `koanf:"tag-selections"`
 }
@@ -99,6 +100,7 @@ func run(configuration exporterConfig) {
 		CollectMaintenances:    configuration.CollectMaintenances,
 		CollectQuotas:          configuration.CollectQuotas,
 		CollectUsages:          configuration.CollectUsages,
+		IncludeTagsInMetrics:   configuration.IncludeTagsInMetrics,
 		TagSelections:          configuration.TagSelections,
 	}
 
@@ -167,6 +169,7 @@ func NewRootCommand() (*cobra.Command, error) {
 	cmd.Flags().BoolP("collect-maintenances", "", true, "Collect AWS instances maintenances")
 	cmd.Flags().BoolP("collect-quotas", "", true, "Collect AWS RDS quotas")
 	cmd.Flags().BoolP("collect-usages", "", true, "Collect AWS RDS usages")
+	cmd.Flags().BoolP("include-tags-in-metrics", "", false, "Include instance tags as labels in all metrics")
 
 	return cmd, nil
 }


### PR DESCRIPTION
### Problem
Previously, RDS instance tags were only available in the dedicated metric. This made it difficult to filter or group other RDS metrics by team, service, environment, or other tag-based identifiers in Prometheus and Grafana, without logic on the datasource part or in the dashboards. Our goal is to filter everything directly from Victoria Metrics without implementing additional logic into any part of the monitoring process, and by using filtering via `extra_label`.

This is described in #255.

### Solution
This PR adds a new `include-tags-in-metrics` flag that allows RDS instance tags to be included as labels in all exported metrics when enabled.


