### PR TITLE
Fix missing IAM permissions for DB clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ If you are running on [AWS EKS](https://aws.amazon.com/eks/), we strongly recomm
             ]
         },
         {
+            "Sid": "AllowClusters",
+            "Effect": "Allow",
+            "Action": [
+                "rds:DescribeDBClusters"
+            ],
+            "Resource": [
+                "arn:aws:rds:*:*:cluster:*"
+            ]
+        },
+        {
             "Sid": "AllowMaintenanceDescriptions",
             "Effect": "Allow",
             "Action": [

--- a/configs/aws/policy.json
+++ b/configs/aws/policy.json
@@ -21,6 +21,16 @@
             ]
         },
         {
+            "Sid": "AllowClusters",
+            "Effect": "Allow",
+            "Action": [
+                "rds:DescribeDBClusters"
+            ],
+            "Resource": [
+                "arn:aws:rds:*:*:cluster:*"
+            ]
+        },
+        {
             "Sid": "AllowMaintenanceDescriptions",
             "Effect": "Allow",
             "Action": [

--- a/configs/terraform/main.tf
+++ b/configs/terraform/main.tf
@@ -37,6 +37,17 @@ data "aws_iam_policy_document" "prometheus-rds-exporter" {
   }
 
   statement {
+    sid    = "AllowClusters"
+    effect = "Allow"
+    actions = [
+      "rds:DescribeDBClusters",
+    ]
+    resources = [
+      "arn:aws:rds:*:*:cluster:*",
+    ]
+  }
+
+  statement {
     sid    = "AllowMaintenanceDescriptions"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
# Goal

Add missing IAM permissions for DB clusters

# Why

Current IAM permissions don't provides the `rds:DescribeDBClusters` DB permissions required since we added support of AWS DB clusters in 0.16.0, but the IAM permissions was not updated.

# How

- Add `rds:DescribeDBClusters` IAM permission in IAM policies. According to AWS best practices, there are located in dedicated statement, with resource limited to rds clusters

# Release plan

It does not requires a release