### PR TITLE
Add network metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ It collects key metrics about:
 | rds_instance_age_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | Time since instance creation |
 | rds_instance_baseline_iops_average | `aws_account_id`, `aws_region`, `instance_class` | Baseline IOPS of underlying EC2 instance class |
 | rds_instance_baseline_throughput_bytes | `aws_account_id`, `aws_region`, `instance_class` | Baseline throughput of underlying EC2 instance class |
+| rds_instance_baseline_network_bandwidth_bytes | `aws_account_id`, `aws_region`, `instance_class` | Baseline network bandwidth of underlying EC2 instance class |
 | rds_instance_info | `arn`, `aws_account_id`, `aws_region`, `dbi_resource_id`, `dbidentifier`, `cluster_identifier`, `deletion_protection`, `engine`, `engine_version`, `instance_class`, `multi_az`, `performance_insights_enabled`, `pending_maintenance`, `pending_modified_values`, `role`, `source_dbidentifier`, `storage_type`, `ca_certificate_identifier` | RDS instance information |
 | rds_instance_log_files_size_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Total of log files on the instance |
 | rds_instance_max_iops_average | `aws_account_id`, `aws_region`, `instance_class` | Maximum IOPS of underlying EC2 instance class |
@@ -74,7 +75,10 @@ It collects key metrics about:
 | rds_max_allocated_storage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Upper limit in gibibytes to which Amazon RDS can automatically scale the storage of the DB instance |
 | rds_max_disk_iops_average | `aws_account_id`, `aws_region`, `dbidentifier` | Max disk IOPS evaluated with disk IOPS and EC2 capacity |
 | rds_max_storage_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Max disk throughput evaluated with disk throughput and EC2 capacity |
+| rds_max_network_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum network throughput of underlying EC2 instance class |
 | rds_maximum_used_transaction_ids_average | `aws_account_id`, `aws_region`, `dbidentifier` | Maximum transaction IDs that have been used. Applies to only PostgreSQL |
+| rds_network_receive_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of bytes received per second from the network |
+| rds_network_transmit_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of bytes transmitted per second to the network |
 | rds_quota_max_dbinstances_average | `aws_account_id`, `aws_region` | Maximum number of RDS instances allowed in the AWS account |
 | rds_quota_maximum_db_instance_snapshots_average | `aws_account_id`, `aws_region` | Maximum number of manual DB instance snapshots |
 | rds_quota_total_storage_bytes | `aws_account_id`, `aws_region` | Maximum total storage for all DB instances |
@@ -83,6 +87,8 @@ It collects key metrics about:
 | rds_replica_lag_seconds | `aws_account_id`, `aws_region`, `dbidentifier` | For read replica configurations, the amount of time a read replica DB instance lags behind the source DB instance. Applies to MariaDB, Microsoft SQL Server, MySQL, Oracle, and PostgreSQL read replicas |
 | rds_replication_slot_disk_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by replication slot files. Applies to PostgreSQL |
 | rds_serverless_instance_acu_average | `aws_account_id`, `aws_region`, `dbidentifier` | Current ACU of the Aurora Serverless instance |
+| rds_storage_network_receive_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of bytes received per second from the Aurora storage subsystem (Aurora only) |
+| rds_storage_network_transmit_throughput_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Average number of bytes transmitted per second to the Aurora storage subsystem (Aurora only) |
 | rds_swap_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Amount of swap space used on the DB instance. This metric is not available for SQL Server |
 | rds_transaction_logs_disk_usage_bytes | `aws_account_id`, `aws_region`, `dbidentifier` | Disk space used by transaction logs (only on PostgreSQL) |
 | rds_usage_allocated_storage_bytes | `aws_account_id`, `aws_region` | Total storage used by AWS RDS instances |

--- a/configs/grafana/dashboards/rds-instance.jsonnet
+++ b/configs/grafana/dashboards/rds-instance.jsonnet
@@ -58,6 +58,7 @@ dashboard.new(title)
       p.timeSeries.memory { gridPos+: { w: 12 } },
       p.timeSeries.diskThroughput { gridPos+: { w: 12 } },
       p.timeSeries.swap { gridPos+: { w: 12 } },
+      p.timeSeries.networkThroughput { gridPos+: { w: 12 } },
       p.timeSeries.storage { gridPos+: { w: 12 } },
       p.timeSeries.status { gridPos+: { w: 12 } },
       p.timeSeries.storagePercent { gridPos+: { w: 12 } },

--- a/configs/grafana/panels/instance.libsonnet
+++ b/configs/grafana/panels/instance.libsonnet
@@ -314,6 +314,49 @@ local colors = common.colors;
         ),
       ]),
 
+    networkThroughput:
+      ts.base('Network throughput', 'The average number of bytes received/transmitted per second from/to the network. Storage network metrics are specific to Aurora storage subsystem.', [queries.instance.network.throughput.receive, queries.instance.network.throughput.transmit, queries.instance.network.throughput.max, queries.instance.network.throughput.storageReceive, queries.instance.network.throughput.storageTransmit])
+      + standardOptions.withDecimals(0)
+      + standardOptions.withUnit('decbytes')
+      + standardOptions.withOverrides([
+        fieldOverride.byName.new('Max')
+        + standardOptions.override.byType.withPropertiesFromOptions(
+          standardOptions.withUnit('decbytes')
+          + custom.withLineWidth('2')
+          + color.withMode('fixed')
+          + color.withFixedColor(colors.danger)
+          + custom.withFillOpacity(0)
+        ),
+        fieldOverride.byName.new('Receive')
+        + standardOptions.override.byType.withPropertiesFromOptions(
+          standardOptions.withUnit('decbytes')
+          + color.withMode('fixed')
+          + color.withFixedColor(colors.ok)
+          + custom.stacking.withMode('normal')
+        ),
+        fieldOverride.byName.new('Transmit')
+        + standardOptions.override.byType.withPropertiesFromOptions(
+          standardOptions.withUnit('decbytes')
+          + color.withMode('fixed')
+          + color.withFixedColor(colors.notice)
+          + custom.stacking.withMode('normal')
+        ),
+        fieldOverride.byName.new('Storage: Receive')
+        + standardOptions.override.byType.withPropertiesFromOptions(
+          standardOptions.withUnit('decbytes')
+          + color.withMode('fixed')
+          + color.withFixedColor(colors.info)
+          + custom.stacking.withMode('normal')
+        ),
+        fieldOverride.byName.new('Storage: Transmit')
+        + standardOptions.override.byType.withPropertiesFromOptions(
+          standardOptions.withUnit('decbytes')
+          + color.withMode('fixed')
+          + color.withFixedColor('purple')
+          + custom.stacking.withMode('normal')
+        ),
+      ]),
+
     memory:
       ts.base('Memory usage', 'The amount of available Random Access Memory', [queries.instance.memory.max, queries.instance.memory.freeable])
       + ts.maxBytes

--- a/configs/grafana/public/rds-instance.json
+++ b/configs/grafana/public/rds-instance.json
@@ -2061,6 +2061,215 @@
             "type": "datasource",
             "uid": "-- Mixed --"
          },
+         "description": "The average number of bytes received/transmitted per second from/to the network. Storage network metrics are specific to Aurora storage subsystem.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "decimals": 0,
+               "min": 0,
+               "unit": "decbytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Max"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.fillOpacity",
+                        "value": 0
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": "2"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "decbytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Receive"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "green",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.stacking",
+                        "value": {
+                           "mode": "normal"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "decbytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Transmit"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "yellow",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.stacking",
+                        "value": {
+                           "mode": "normal"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "decbytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Storage: Receive"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "blue",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.stacking",
+                        "value": {
+                           "mode": "normal"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "decbytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Storage: Transmit"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "purple",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.stacking",
+                        "value": {
+                           "mode": "normal"
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "decbytes"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 38
+         },
+         "id": 33,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "min",
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right"
+            }
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "max(rds_network_receive_throughput_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"})\n",
+               "legendFormat": "Receive"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "max(rds_network_transmit_throughput_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"})\n",
+               "legendFormat": "Transmit"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "max(rds_max_network_throughput_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"})\n",
+               "legendFormat": "Max"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "max(rds_storage_network_receive_throughput_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"})\n",
+               "legendFormat": "Storage: Receive"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "max(rds_storage_network_transmit_throughput_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"})\n",
+               "legendFormat": "Storage: Transmit"
+            }
+         ],
+         "title": "Network throughput",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
          "description": "Storage size per type. WAL only applied to PostgreSQL",
          "fieldConfig": {
             "defaults": {
@@ -2221,10 +2430,10 @@
          "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 38
+            "x": 0,
+            "y": 46
          },
-         "id": 33,
+         "id": 34,
          "options": {
             "legend": {
                "calcs": [
@@ -2447,10 +2656,10 @@
          "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
+            "x": 12,
             "y": 46
          },
-         "id": 34,
+         "id": 35,
          "options": {
             "legend": {
                "calcs": [
@@ -2499,7 +2708,7 @@
                      "mode": "line"
                   }
                },
-               "decimals": 0,
+               "decimals": null,
                "max": 100,
                "min": 0,
                "thresholds": {
@@ -2521,10 +2730,10 @@
          "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 46
+            "x": 0,
+            "y": 54
          },
-         "id": 35,
+         "id": 36,
          "options": {
             "legend": {
                "calcs": [
@@ -2555,10 +2764,10 @@
          "gridPos": {
             "h": 1,
             "w": 0,
-            "x": 24,
-            "y": 54
+            "x": 12,
+            "y": 62
          },
-         "id": 36,
+         "id": 37,
          "title": "PostgreSQL",
          "type": "row"
       },
@@ -2603,9 +2812,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 55
+            "y": 63
          },
-         "id": 37,
+         "id": 38,
          "options": {
             "legend": {
                "calcs": [
@@ -2651,9 +2860,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 55
+            "y": 63
          },
-         "id": 38,
+         "id": 39,
          "options": {
             "legend": {
                "calcs": [
@@ -2685,9 +2894,9 @@
             "h": 1,
             "w": 0,
             "x": 24,
-            "y": 63
+            "y": 71
          },
-         "id": 39,
+         "id": 40,
          "title": "Scaling capacity",
          "type": "row"
       },
@@ -2780,9 +2989,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 72
          },
-         "id": 40,
+         "id": 41,
          "options": {
             "legend": {
                "calcs": [
@@ -2881,9 +3090,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 72
          },
-         "id": 41,
+         "id": 42,
          "options": {
             "legend": {
                "calcs": [
@@ -2998,9 +3207,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 80
          },
-         "id": 42,
+         "id": 43,
          "options": {
             "legend": {
                "calcs": [

--- a/configs/grafana/public/rds-instances.json
+++ b/configs/grafana/public/rds-instances.json
@@ -1062,7 +1062,7 @@
                   },
                   "indexByName": {
                      "Time": 2,
-                     "Value": 18,
+                     "Value": 19,
                      "aws_account_id": 0,
                      "aws_region": 1,
                      "ca_certificate_identifier": 16,

--- a/configs/grafana/queries/instance.libsonnet
+++ b/configs/grafana/queries/instance.libsonnet
@@ -397,6 +397,54 @@ local variables = import '../variables.libsonnet';
         + prometheusQuery.withLegendFormat('{{dbidentifier}}'),
 
     },
+    network: {
+      throughput: {
+        receive:
+          prometheusQuery.new(
+            '$' + variables.datasource.name,
+            |||
+              max(rds_network_receive_throughput_bytes{aws_account_id="$aws_account_id",aws_region="$aws_region",dbidentifier="$dbidentifier"})
+            |||
+          )
+          + prometheusQuery.withLegendFormat('Receive'),
+
+        transmit:
+          prometheusQuery.new(
+            '$' + variables.datasource.name,
+            |||
+              max(rds_network_transmit_throughput_bytes{aws_account_id="$aws_account_id",aws_region="$aws_region",dbidentifier="$dbidentifier"})
+            |||
+          )
+          + prometheusQuery.withLegendFormat('Transmit'),
+
+        max:
+          prometheusQuery.new(
+            '$' + variables.datasource.name,
+            |||
+              max(rds_max_network_throughput_bytes{aws_account_id="$aws_account_id",aws_region="$aws_region",dbidentifier="$dbidentifier"})
+            |||
+          )
+          + prometheusQuery.withLegendFormat('Max'),
+
+        storageReceive:
+          prometheusQuery.new(
+            '$' + variables.datasource.name,
+            |||
+              max(rds_storage_network_receive_throughput_bytes{aws_account_id="$aws_account_id",aws_region="$aws_region",dbidentifier="$dbidentifier"})
+            |||
+          )
+          + prometheusQuery.withLegendFormat('Storage: Receive'),
+
+        storageTransmit:
+          prometheusQuery.new(
+            '$' + variables.datasource.name,
+            |||
+              max(rds_storage_network_transmit_throughput_bytes{aws_account_id="$aws_account_id",aws_region="$aws_region",dbidentifier="$dbidentifier"})
+            |||
+          )
+          + prometheusQuery.withLegendFormat('Storage: Transmit'),
+      },
+    },
     backup: {
       retention:
         prometheusQuery.new(

--- a/internal/app/cloudwatch/rds.go
+++ b/internal/app/cloudwatch/rds.go
@@ -27,23 +27,27 @@ type CloudWatchMetrics struct {
 }
 
 type RdsMetrics struct {
-	CPUUtilization             *float64
-	DBLoad                     *float64
-	DBLoadCPU                  *float64
-	DBLoadNonCPU               *float64
-	DatabaseConnections        *float64
-	FreeStorageSpace           *float64
-	FreeableMemory             *float64
-	MaximumUsedTransactionIDs  *float64
-	ReadIOPS                   *float64
-	ReadThroughput             *float64
-	ReplicaLag                 *float64
-	ReplicationSlotDiskUsage   *float64
-	SwapUsage                  *float64
-	TransactionLogsDiskUsage   *float64
-	ServerlessDatabaseCapacity *float64
-	WriteIOPS                  *float64
-	WriteThroughput            *float64
+	CPUUtilization                   *float64
+	DatabaseConnections              *float64
+	DBLoad                           *float64
+	DBLoadCPU                        *float64
+	DBLoadNonCPU                     *float64
+	FreeableMemory                   *float64
+	FreeStorageSpace                 *float64
+	MaximumUsedTransactionIDs        *float64
+	NetworkReceiveThroughput         *float64
+	NetworkTransmitThroughput        *float64
+	ReadIOPS                         *float64
+	ReadThroughput                   *float64
+	ReplicaLag                       *float64
+	ReplicationSlotDiskUsage         *float64
+	ServerlessDatabaseCapacity       *float64
+	StorageNetworkReceiveThroughput  *float64
+	StorageNetworkTransmitThroughput *float64
+	SwapUsage                        *float64
+	TransactionLogsDiskUsage         *float64
+	WriteIOPS                        *float64
+	WriteThroughput                  *float64
 }
 
 func (m *RdsMetrics) Update(field string, value float64) error {
@@ -62,6 +66,10 @@ func (m *RdsMetrics) Update(field string, value float64) error {
 		m.FreeStorageSpace = &value
 	case "FreeableMemory":
 		m.FreeableMemory = &value
+	case "NetworkReceiveThroughput":
+		m.NetworkReceiveThroughput = &value
+	case "NetworkTransmitThroughput":
+		m.NetworkTransmitThroughput = &value
 	case "SwapUsage":
 		m.SwapUsage = &value
 	case "WriteIOPS":
@@ -82,6 +90,10 @@ func (m *RdsMetrics) Update(field string, value float64) error {
 		m.TransactionLogsDiskUsage = &value
 	case "ServerlessDatabaseCapacity":
 		m.ServerlessDatabaseCapacity = &value
+	case "StorageNetworkReceiveThroughput":
+		m.StorageNetworkReceiveThroughput = &value
+	case "StorageNetworkTransmitThroughput":
+		m.StorageNetworkTransmitThroughput = &value
 	default:
 		return fmt.Errorf("can't process '%s' metrics: %w", field, errUnknownMetric)
 	}
@@ -90,8 +102,8 @@ func (m *RdsMetrics) Update(field string, value float64) error {
 }
 
 // getCloudWatchMetricsName returns names of Cloudwatch metrics to collect
-func getCloudWatchMetricsName() [17]string {
-	return [17]string{
+func getCloudWatchMetricsName() [21]string {
+	return [21]string{
 		"CPUUtilization",
 		"DBLoad",
 		"DBLoadCPU",
@@ -100,12 +112,16 @@ func getCloudWatchMetricsName() [17]string {
 		"FreeStorageSpace",
 		"FreeableMemory",
 		"MaximumUsedTransactionIDs",
+		"NetworkReceiveThroughput",
+		"NetworkTransmitThroughput",
 		"ReadIOPS",
 		"ReadThroughput",
 		"ReplicaLag",
 		"ReplicationSlotDiskUsage",
 		"SwapUsage",
 		"ServerlessDatabaseCapacity",
+		"StorageNetworkReceiveThroughput",
+		"StorageNetworkTransmitThroughput",
 		"TransactionLogsDiskUsage",
 		"WriteIOPS",
 		"WriteThroughput",

--- a/internal/app/ec2/ec2.go
+++ b/internal/app/ec2/ec2.go
@@ -21,12 +21,13 @@ const (
 var tracer = otel.Tracer("github/qonto/prometheus-rds-exporter/internal/app/ec2")
 
 type EC2InstanceMetrics struct {
-	BaselineIOPS       int32
-	BaselineThroughput float64
-	MaximumIops        int32
-	MaximumThroughput  float64
-	Memory             int64
-	Vcpu               int32
+	BaselineIOPS             int32
+	BaselineThroughput       float64
+	MaximumIops              int32
+	MaximumThroughput        float64
+	Memory                   int64
+	Vcpu                     int32
+	BaselineNetworkBandwidth float64
 }
 
 type Metrics struct {
@@ -107,6 +108,13 @@ func (e *EC2Fetcher) GetDBInstanceTypeInformation(instanceTypes []string) (Metri
 
 				instanceMetrics.MaximumIops = aws.ToInt32(i.EbsInfo.EbsOptimizedInfo.MaximumIops)
 				instanceMetrics.MaximumThroughput = converter.MegaBytesToBytes(aws.ToFloat64(i.EbsInfo.EbsOptimizedInfo.MaximumThroughputInMBps))
+			}
+
+			if i.NetworkInfo != nil && i.NetworkInfo.NetworkCards != nil && len(i.NetworkInfo.NetworkCards) > 0 {
+				// Use the baseline bandwidth from the first network card (primary network interface)
+				if i.NetworkInfo.NetworkCards[0].BaselineBandwidthInGbps != nil {
+					instanceMetrics.BaselineNetworkBandwidth = converter.GigaBytesToBytesSI(aws.ToFloat64(i.NetworkInfo.NetworkCards[0].BaselineBandwidthInGbps))
+				}
 			}
 
 			instanceName := addDBPrefix(string(i.InstanceType))

--- a/internal/app/exporter/exporter.go
+++ b/internal/app/exporter/exporter.go
@@ -75,55 +75,61 @@ type rdsCollector struct {
 	cloudWatchClient    cloudWatchClient
 	tagClient           resourcegroupstaggingapi.GetResourcesAPIClient
 
-	errors                      *prometheus.Desc
-	DBLoad                      *prometheus.Desc
-	dBLoadCPU                   *prometheus.Desc
-	dBLoadNonCPU                *prometheus.Desc
-	allocatedStorage            *prometheus.Desc
-	allocatedDiskIOPS           *prometheus.Desc
-	allocatedDiskThroughput     *prometheus.Desc
-	information                 *prometheus.Desc
-	clusterInformation          *prometheus.Desc
-	clusterServerLessMaxACU     *prometheus.Desc
-	clusterServerLessMinACU     *prometheus.Desc
-	instanceBaselineIops        *prometheus.Desc
-	instanceMaximumIops         *prometheus.Desc
-	instanceBaselineThroughput  *prometheus.Desc
-	instanceMaximumThroughput   *prometheus.Desc
-	instanceMemory              *prometheus.Desc
-	instanceVCPU                *prometheus.Desc
-	instanceTags                *prometheus.Desc
-	logFilesSize                *prometheus.Desc
-	maxAllocatedStorage         *prometheus.Desc
-	maxIops                     *prometheus.Desc
-	status                      *prometheus.Desc
-	storageThroughput           *prometheus.Desc
-	up                          *prometheus.Desc
-	cpuUtilisation              *prometheus.Desc
-	freeStorageSpace            *prometheus.Desc
-	databaseConnections         *prometheus.Desc
-	freeableMemory              *prometheus.Desc
-	swapUsage                   *prometheus.Desc
-	writeIOPS                   *prometheus.Desc
-	readIOPS                    *prometheus.Desc
-	replicaLag                  *prometheus.Desc
-	replicationSlotDiskUsage    *prometheus.Desc
-	maximumUsedTransactionIDs   *prometheus.Desc
-	apiCall                     *prometheus.Desc
-	readThroughput              *prometheus.Desc
-	writeThroughput             *prometheus.Desc
-	backupRetentionPeriod       *prometheus.Desc
-	quotaDBInstances            *prometheus.Desc
-	quotaTotalStorage           *prometheus.Desc
-	quotaMaxDBInstanceSnapshots *prometheus.Desc
-	usageAllocatedStorage       *prometheus.Desc
-	usageDBInstances            *prometheus.Desc
-	usageManualSnapshots        *prometheus.Desc
-	serverlessDatabaseCapacity  *prometheus.Desc
-	exporterBuildInformation    *prometheus.Desc
-	transactionLogsDiskUsage    *prometheus.Desc
-	certificateValidTill        *prometheus.Desc
-	age                         *prometheus.Desc
+	errors                           *prometheus.Desc
+	DBLoad                           *prometheus.Desc
+	dBLoadCPU                        *prometheus.Desc
+	dBLoadNonCPU                     *prometheus.Desc
+	allocatedStorage                 *prometheus.Desc
+	allocatedDiskIOPS                *prometheus.Desc
+	allocatedDiskThroughput          *prometheus.Desc
+	information                      *prometheus.Desc
+	clusterInformation               *prometheus.Desc
+	clusterServerLessMaxACU          *prometheus.Desc
+	clusterServerLessMinACU          *prometheus.Desc
+	instanceBaselineIops             *prometheus.Desc
+	instanceMaximumIops              *prometheus.Desc
+	instanceBaselineThroughput       *prometheus.Desc
+	instanceMaximumThroughput        *prometheus.Desc
+	instanceBaselineNetworkBandwidth *prometheus.Desc
+	instanceMemory                   *prometheus.Desc
+	instanceVCPU                     *prometheus.Desc
+	instanceTags                     *prometheus.Desc
+	logFilesSize                     *prometheus.Desc
+	maxAllocatedStorage              *prometheus.Desc
+	maxIops                          *prometheus.Desc
+	status                           *prometheus.Desc
+	storageThroughput                *prometheus.Desc
+	maxNetworkThroughput             *prometheus.Desc
+	networkReceiveThroughput         *prometheus.Desc
+	networkTransmitThroughput        *prometheus.Desc
+	up                               *prometheus.Desc
+	cpuUtilisation                   *prometheus.Desc
+	freeStorageSpace                 *prometheus.Desc
+	databaseConnections              *prometheus.Desc
+	freeableMemory                   *prometheus.Desc
+	swapUsage                        *prometheus.Desc
+	writeIOPS                        *prometheus.Desc
+	readIOPS                         *prometheus.Desc
+	replicaLag                       *prometheus.Desc
+	replicationSlotDiskUsage         *prometheus.Desc
+	maximumUsedTransactionIDs        *prometheus.Desc
+	apiCall                          *prometheus.Desc
+	readThroughput                   *prometheus.Desc
+	writeThroughput                  *prometheus.Desc
+	storageNetworkReceiveThroughput  *prometheus.Desc
+	storageNetworkTransmitThroughput *prometheus.Desc
+	backupRetentionPeriod            *prometheus.Desc
+	quotaDBInstances                 *prometheus.Desc
+	quotaTotalStorage                *prometheus.Desc
+	quotaMaxDBInstanceSnapshots      *prometheus.Desc
+	usageAllocatedStorage            *prometheus.Desc
+	usageDBInstances                 *prometheus.Desc
+	usageManualSnapshots             *prometheus.Desc
+	serverlessDatabaseCapacity       *prometheus.Desc
+	exporterBuildInformation         *prometheus.Desc
+	transactionLogsDiskUsage         *prometheus.Desc
+	certificateValidTill             *prometheus.Desc
+	age                              *prometheus.Desc
 }
 
 func NewCollector(logger slog.Logger, collectorConfiguration Configuration, awsAccountID string, awsRegion string, rdsClient rdsClient, ec2Client EC2Client, cloudWatchClient cloudWatchClient, servicequotasClient servicequotasClient, tagClient resourcegroupstaggingapi.GetResourcesAPIClient) *rdsCollector {
@@ -191,12 +197,32 @@ func NewCollector(logger slog.Logger, collectorConfiguration Configuration, awsA
 			"Max disk throughput evaluated with disk throughput and EC2 capacity",
 			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
+		maxNetworkThroughput: prometheus.NewDesc("rds_max_network_throughput_bytes",
+			"Maximum network throughput of underlying EC2 instance class",
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
+		),
+		networkReceiveThroughput: prometheus.NewDesc("rds_network_receive_throughput_bytes",
+			"Average number of bytes received per second from the network",
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
+		),
+		networkTransmitThroughput: prometheus.NewDesc("rds_network_transmit_throughput_bytes",
+			"Average number of bytes transmitted per second to the network",
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
+		),
 		readThroughput: prometheus.NewDesc("rds_read_throughput_bytes",
 			"Average number of bytes read from disk per second",
 			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		writeThroughput: prometheus.NewDesc("rds_write_throughput_bytes",
 			"Average number of bytes written to disk per second",
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
+		),
+		storageNetworkReceiveThroughput: prometheus.NewDesc("rds_storage_network_receive_throughput_bytes",
+			"Average number of bytes received per second from the Aurora storage subsystem (Aurora only)",
+			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
+		),
+		storageNetworkTransmitThroughput: prometheus.NewDesc("rds_storage_network_transmit_throughput_bytes",
+			"Average number of bytes transmitted per second to the Aurora storage subsystem (Aurora only)",
 			[]string{"aws_account_id", "aws_region", "dbidentifier"}, nil,
 		),
 		status: prometheus.NewDesc("rds_instance_status",
@@ -237,6 +263,10 @@ func NewCollector(logger slog.Logger, collectorConfiguration Configuration, awsA
 		),
 		instanceBaselineIops: prometheus.NewDesc("rds_instance_baseline_iops_average",
 			"Baseline IOPS of underlying EC2 instance class",
+			[]string{"aws_account_id", "aws_region", "instance_class"}, nil,
+		),
+		instanceBaselineNetworkBandwidth: prometheus.NewDesc("rds_instance_baseline_network_bandwidth_bytes",
+			"Baseline network bandwidth of underlying EC2 instance class",
 			[]string{"aws_account_id", "aws_region", "instance_class"}, nil,
 		),
 		freeStorageSpace: prometheus.NewDesc("rds_free_storage_bytes",
@@ -362,12 +392,16 @@ func (c *rdsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.instanceMaximumIops
 	ch <- c.instanceBaselineThroughput
 	ch <- c.instanceMaximumThroughput
+	ch <- c.instanceBaselineNetworkBandwidth
 	ch <- c.instanceMemory
 	ch <- c.instanceVCPU
 	ch <- c.logFilesSize
 	ch <- c.maxAllocatedStorage
 	ch <- c.maxIops
 	ch <- c.maximumUsedTransactionIDs
+	ch <- c.maxNetworkThroughput
+	ch <- c.networkReceiveThroughput
+	ch <- c.networkTransmitThroughput
 	ch <- c.quotaDBInstances
 	ch <- c.quotaMaxDBInstanceSnapshots
 	ch <- c.quotaTotalStorage
@@ -377,6 +411,8 @@ func (c *rdsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.replicationSlotDiskUsage
 	ch <- c.status
 	ch <- c.storageThroughput
+	ch <- c.storageNetworkReceiveThroughput
+	ch <- c.storageNetworkTransmitThroughput
 	ch <- c.swapUsage
 	ch <- c.transactionLogsDiskUsage
 	ch <- c.up
@@ -668,6 +704,13 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.storageThroughput, prometheus.GaugeValue, storageThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
 		}
 
+		// Network throughput from EC2 instance type
+		if ec2Metrics, ok := c.metrics.EC2.Instances[instance.DBInstanceClass]; ok {
+			if ec2Metrics.BaselineNetworkBandwidth > 0 {
+				ch <- prometheus.MustNewConstMetric(c.maxNetworkThroughput, prometheus.GaugeValue, ec2Metrics.BaselineNetworkBandwidth, c.awsAccountID, c.awsRegion, dbidentifier)
+			}
+		}
+
 		if c.configuration.CollectInstanceTags {
 			names, values := c.getInstanceTagLabels(dbidentifier, instance)
 
@@ -736,6 +779,14 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.writeThroughput, prometheus.GaugeValue, *instance.WriteThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
 		}
 
+		if instance.StorageNetworkReceiveThroughput != nil {
+			ch <- prometheus.MustNewConstMetric(c.storageNetworkReceiveThroughput, prometheus.GaugeValue, *instance.StorageNetworkReceiveThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
+		}
+
+		if instance.StorageNetworkTransmitThroughput != nil {
+			ch <- prometheus.MustNewConstMetric(c.storageNetworkTransmitThroughput, prometheus.GaugeValue, *instance.StorageNetworkTransmitThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
+		}
+
 		if instance.TransactionLogsDiskUsage != nil {
 			ch <- prometheus.MustNewConstMetric(c.transactionLogsDiskUsage, prometheus.GaugeValue, *instance.TransactionLogsDiskUsage, c.awsAccountID, c.awsRegion, dbidentifier)
 		}
@@ -759,6 +810,14 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 		if instance.ServerlessDatabaseCapacity != nil {
 			ch <- prometheus.MustNewConstMetric(c.serverlessDatabaseCapacity, prometheus.GaugeValue, *instance.ServerlessDatabaseCapacity, c.awsAccountID, c.awsRegion, dbidentifier)
 		}
+
+		if instance.NetworkReceiveThroughput != nil {
+			ch <- prometheus.MustNewConstMetric(c.networkReceiveThroughput, prometheus.GaugeValue, *instance.NetworkReceiveThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
+		}
+
+		if instance.NetworkTransmitThroughput != nil {
+			ch <- prometheus.MustNewConstMetric(c.networkTransmitThroughput, prometheus.GaugeValue, *instance.NetworkTransmitThroughput, c.awsAccountID, c.awsRegion, dbidentifier)
+		}
 	}
 
 	// usage metrics
@@ -778,6 +837,9 @@ func (c *rdsCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.instanceMaximumThroughput, prometheus.GaugeValue, instance.MaximumThroughput, c.awsAccountID, c.awsRegion, instanceType)
 		ch <- prometheus.MustNewConstMetric(c.instanceMemory, prometheus.GaugeValue, float64(instance.Memory), c.awsAccountID, c.awsRegion, instanceType)
 		ch <- prometheus.MustNewConstMetric(c.instanceVCPU, prometheus.GaugeValue, float64(instance.Vcpu), c.awsAccountID, c.awsRegion, instanceType)
+		if instance.BaselineNetworkBandwidth > 0 {
+			ch <- prometheus.MustNewConstMetric(c.instanceBaselineNetworkBandwidth, prometheus.GaugeValue, instance.BaselineNetworkBandwidth, c.awsAccountID, c.awsRegion, instanceType)
+		}
 	}
 
 	// serviceQuotas metrics

--- a/internal/app/unit/converter.go
+++ b/internal/app/unit/converter.go
@@ -14,6 +14,12 @@ func GigaBytesToBytes[N Number](size N) N {
 	return size * unit * unit * unit
 }
 
+// GigaBytesToBytesSI converts Gigabytes to Bytes using SI (decimal) units
+// Relevant for networking speeds that are defined in decimal units.
+func GigaBytesToBytesSI[N Number](size N) N {
+	return size * 1000 * 1000 * 1000
+}
+
 func MegaBytesToBytes[N Number](size N) N {
 	return size * unit * unit
 }


### PR DESCRIPTION
# Goal

Add network metrics to exporter and dashboards

# Why

Network saturation could lead to degraded performances. For Aurora it may be helpful to identify distributed storage usage.

# How

- Collect `NetworkTransmitThroughput`, `NetworkReceiveThroughput` for RDS + Aurora
- Collect `StorageNetworkReceiveThroughput` and `StorageNetworkTransmitThroughput` for Aurora 
- Network bandwidth baseline (aka max) depends of the instance type and is available in AWS golang SDK. This information is not available for Aurora Serverless.
- Integrate all 5 metrics in instance dashboard
   - RDS: <img width="3024" height="1730" alt="rds" src="https://github.com/user-attachments/assets/6254c0fc-d7d3-4119-a3e2-a472c9e29004" />
   - Aurora Serverless (max is not available) : <img width="3024" height="1730" alt="serverless" src="https://github.com/user-attachments/assets/741ee3ad-a9b2-40e7-a3fc-231baad55fc0" />


Resources:

- [Amazon CloudWatch metrics for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-metrics.html)
- [Amazon CloudWatch metrics for Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraMonitoring.Metrics.html)

# Plan

Release new minor version