### PR TITLE
fix(dashboard): aggregate storage usage to avoid duplicate series

### DIFF
--- a/configs/grafana/public/rds-instance.json
+++ b/configs/grafana/public/rds-instance.json
@@ -799,7 +799,7 @@
             "type": "datasource",
             "uid": "-- Mixed --"
          },
-         "description": "Days before end of standard support. After the standard support period ends, AWS will continue providing security patches and critical fixes for that engine version during the Extended Support window to give you more time to upgrade. But an additional Extended Support cost will be applied until you upgrade. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.htmla",
+         "description": "Days before end of standard support. After the standard support period ends, AWS will continue providing security patches and critical fixes for that engine version during the Extended Support window to give you more time to upgrade. But an additional Extended Support cost will be applied until you upgrade. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
@@ -1130,7 +1130,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "(\n  100 -(\n    rds_free_storage_bytes{aws_account_id=\"$aws_account_id\", aws_region=\"$aws_region\", dbidentifier=\"$dbidentifier\"} * 100\n  ) / rds_allocated_storage_bytes{aws_account_id=\"$aws_account_id\", aws_region=\"$aws_region\", dbidentifier=\"$dbidentifier\"}\n) or on(aws_account_id, aws_region, dbidentifier) (\n  max by (aws_account_id, aws_region, dbidentifier) (\n    rds_allocated_storage_bytes{aws_account_id=\"$aws_account_id\", aws_region=\"$aws_region\", dbidentifier=\"$dbidentifier\"}\n  ) * 100 / (281474976710656)\n)",
+               "expr": "(\n  100 - max by (aws_account_id, aws_region, dbidentifier) (\n    rds_free_storage_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"}\n    * 100\n    / rds_allocated_storage_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"}\n  )\n) or on(aws_account_id, aws_region, dbidentifier) (\n  max by (aws_account_id, aws_region, dbidentifier) (\n    rds_allocated_storage_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"}\n  )\n  * 100\n  / 281474976710656\n)\n",
                "legendFormat": "{{dbidentifier}}"
             }
          ],
@@ -2874,7 +2874,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "(\n  100 -(\n    rds_free_storage_bytes{aws_account_id=\"$aws_account_id\", aws_region=\"$aws_region\", dbidentifier=\"$dbidentifier\"} * 100\n  ) / rds_allocated_storage_bytes{aws_account_id=\"$aws_account_id\", aws_region=\"$aws_region\", dbidentifier=\"$dbidentifier\"}\n) or on(aws_account_id, aws_region, dbidentifier) (\n  max by (aws_account_id, aws_region, dbidentifier) (\n    rds_allocated_storage_bytes{aws_account_id=\"$aws_account_id\", aws_region=\"$aws_region\", dbidentifier=\"$dbidentifier\"}\n  ) * 100 / (281474976710656)\n)",
+               "expr": "(\n  100 - max by (aws_account_id, aws_region, dbidentifier) (\n    rds_free_storage_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"}\n    * 100\n    / rds_allocated_storage_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"}\n  )\n) or on(aws_account_id, aws_region, dbidentifier) (\n  max by (aws_account_id, aws_region, dbidentifier) (\n    rds_allocated_storage_bytes{aws_account_id=\"$aws_account_id\",aws_region=\"$aws_region\",dbidentifier=\"$dbidentifier\"}\n  )\n  * 100\n  / 281474976710656\n)\n",
                "legendFormat": "{{dbidentifier}}"
             }
          ],

--- a/configs/grafana/public/rds-instances.json
+++ b/configs/grafana/public/rds-instances.json
@@ -1,0 +1,1853 @@
+{
+   "description": "RDS instances inventory",
+   "editable": false,
+   "graphTooltip": 1,
+   "links": [
+      {
+         "asDropdown": true,
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "dmf",
+            "server"
+         ],
+         "title": "Server",
+         "type": "dashboards"
+      },
+      {
+         "asDropdown": true,
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "dmf",
+            "database"
+         ],
+         "title": "Database",
+         "type": "dashboards"
+      },
+      {
+         "asDropdown": true,
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "dmf",
+            "table"
+         ],
+         "title": "Table",
+         "type": "dashboards"
+      },
+      {
+         "asDropdown": true,
+         "includeVars": true,
+         "keepTime": true,
+         "tags": [
+            "dmf",
+            "misc"
+         ],
+         "title": "More",
+         "type": "dashboards"
+      }
+   ],
+   "panels": [
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 0,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "title": "Overview",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Number of AWS RDS instances in selected AWS account(s) and region(s)",
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "white",
+                        "value": 0
+                     }
+                  ]
+               }
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 0,
+            "y": 1
+         },
+         "id": 2,
+         "options": {
+            "graphMode": "area"
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "count(rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"})\n"
+            }
+         ],
+         "title": "Instances",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Total number of RDS instances with a pending maintenance",
+         "fieldConfig": {
+            "defaults": {
+               "noValue": "0",
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "orange",
+                        "value": 1
+                     }
+                  ]
+               }
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 3,
+            "y": 1
+         },
+         "id": 3,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "area"
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "count(rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\",pending_maintenance!=\"no\"} > 0)\n"
+            }
+         ],
+         "title": "Pending maintenances",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Total number of RDS instances with a pending modification",
+         "fieldConfig": {
+            "defaults": {
+               "noValue": "0",
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "orange",
+                        "value": 1
+                     }
+                  ]
+               }
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 6,
+            "y": 1
+         },
+         "id": 4,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "area"
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "count(rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\",pending_modified_values!=\"false\"})\n"
+            }
+         ],
+         "title": "Pending modifications",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Total number of RDS instances with deprecated certificate",
+         "fieldConfig": {
+            "defaults": {
+               "noValue": "0",
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "orange",
+                        "value": 1
+                     }
+                  ]
+               }
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 9,
+            "y": 1
+         },
+         "id": 5,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "area"
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "count(rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\", ca_certificate_identifier!=\"rds-ca-rsa2048-g1\"})\n"
+            }
+         ],
+         "title": "Deprecated certificates",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Total number of RDS instances with standard support ending soon",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 0,
+               "noValue": "0",
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "orange",
+                        "value": 1
+                     }
+                  ]
+               }
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 12,
+            "y": 1
+         },
+         "id": 6,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "area"
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "count(\n  rds_standard_support_engine_remaining_days{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"} < 90\n  and\n  rds_standard_support_engine_remaining_days{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"} > 0\n  )\n"
+            }
+         ],
+         "title": "Standard support ending soon",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Total number of RDS instances running with extended support",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 0,
+               "noValue": "0",
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "orange",
+                        "value": 1
+                     }
+                  ]
+               }
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 15,
+            "y": 1
+         },
+         "id": 7,
+         "options": {
+            "colorMode": "background",
+            "graphMode": "area"
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "count(rds_standard_support_engine_remaining_days{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"} < 0)\n"
+            }
+         ],
+         "title": "Extended support",
+         "type": "stat"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 0,
+            "x": 18,
+            "y": 4
+         },
+         "id": 8,
+         "title": "Pending operations",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "RDS instances with pending maintenance",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "displayMode": "color-text"
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "white",
+                        "value": 0
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "dbidentifier"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "",
+                              "url": "/d/a7049b32-6be3-42e5-aa9a-2879a14f46dd/?${datasource:queryparam}&${__url_time_range}&var-aws_account_id=${__data.fields.aws_account_id}&var-aws_region=${__data.fields.aws_region}&var-dbidentifier=${__data.fields.dbidentifier}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "cluster_identifier"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "",
+                              "url": "/d/0197d764-40cc-7042-a4df-f2e3146275a6/?${datasource:queryparam}&${__url_time_range}&var-aws_account_id=${__data.fields.aws_account_id}&var-aws_region=${__data.fields.aws_region}&var-cluster_identifier=${__data.fields.cluster_identifier}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "multi_az"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "deletion_protection"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pending_modified_values"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "green",
+                                    "index": 0
+                                 },
+                                 "true": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "performance_insights_enabled"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pending_maintenance"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "auto-applied": {
+                                    "color": "orange",
+                                    "index": 0
+                                 },
+                                 "forced": {
+                                    "color": "red",
+                                    "index": 1
+                                 },
+                                 "no": {
+                                    "color": "green",
+                                    "index": 0
+                                 },
+                                 "pending": {
+                                    "color": "yellow",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 5
+         },
+         "id": 9,
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\",pending_maintenance!=\"no\"}\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Instances with pending maintenance",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value": true,
+                     "__name__": true,
+                     "arn": true,
+                     "ca_certificate_identifier": true,
+                     "container": true,
+                     "context": true,
+                     "dbi_resource_id": true,
+                     "deletion_protection": true,
+                     "endpoint": true,
+                     "engine": true,
+                     "engine_version": true,
+                     "environment": true,
+                     "instance": true,
+                     "instance_class": true,
+                     "job": true,
+                     "kubernetes_cluster": true,
+                     "multi_az": true,
+                     "namespace": true,
+                     "pending_modified_values": true,
+                     "performance_insights_enabled": true,
+                     "pod": true,
+                     "prometheus": true,
+                     "role": true,
+                     "service": true,
+                     "source_dbidentifier": true,
+                     "storage_type": true
+                  },
+                  "indexByName": {
+                     "aws_account_id": 1,
+                     "aws_region": 2,
+                     "dbidentifier": 3,
+                     "pending_maintenance": 4
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "RDS instances with pending modification",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "displayMode": "color-text"
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "white",
+                        "value": 0
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "dbidentifier"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "",
+                              "url": "/d/a7049b32-6be3-42e5-aa9a-2879a14f46dd/?${datasource:queryparam}&${__url_time_range}&var-aws_account_id=${__data.fields.aws_account_id}&var-aws_region=${__data.fields.aws_region}&var-dbidentifier=${__data.fields.dbidentifier}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "cluster_identifier"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "",
+                              "url": "/d/0197d764-40cc-7042-a4df-f2e3146275a6/?${datasource:queryparam}&${__url_time_range}&var-aws_account_id=${__data.fields.aws_account_id}&var-aws_region=${__data.fields.aws_region}&var-cluster_identifier=${__data.fields.cluster_identifier}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "multi_az"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "deletion_protection"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pending_modified_values"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "green",
+                                    "index": 0
+                                 },
+                                 "true": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "performance_insights_enabled"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pending_maintenance"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "auto-applied": {
+                                    "color": "orange",
+                                    "index": 0
+                                 },
+                                 "forced": {
+                                    "color": "red",
+                                    "index": 1
+                                 },
+                                 "no": {
+                                    "color": "green",
+                                    "index": 0
+                                 },
+                                 "pending": {
+                                    "color": "yellow",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 5
+         },
+         "id": 10,
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\",pending_modified_values!=\"false\"}\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Instances with pending modification",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value": true,
+                     "__name__": true,
+                     "arn": true,
+                     "ca_certificate_identifier": true,
+                     "container": true,
+                     "context": true,
+                     "dbi_resource_id": true,
+                     "deletion_protection": true,
+                     "endpoint": true,
+                     "engine": true,
+                     "engine_version": true,
+                     "environment": true,
+                     "instance": true,
+                     "instance_class": true,
+                     "job": true,
+                     "kubernetes_cluster": true,
+                     "multi_az": true,
+                     "namespace": true,
+                     "pending_maintenance": true,
+                     "performance_insights_enabled": true,
+                     "pod": true,
+                     "prometheus": true,
+                     "role": true,
+                     "service": true,
+                     "source_dbidentifier": true,
+                     "storage_type": true
+                  },
+                  "indexByName": {
+                     "aws_account_id": 1,
+                     "aws_region": 2,
+                     "dbidentifier": 3,
+                     "pending_modified_values": 4
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 0,
+            "x": 24,
+            "y": 10
+         },
+         "id": 11,
+         "title": "Standard and extended support",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "RDS instances with standard support will be ending in the near future.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "displayMode": "color-text"
+               },
+               "decimals": 0,
+               "noValue": "No instance",
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "white",
+                        "value": 0
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "dbidentifier"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "",
+                              "url": "/d/a7049b32-6be3-42e5-aa9a-2879a14f46dd/?${datasource:queryparam}&${__url_time_range}&var-aws_account_id=${__data.fields.aws_account_id}&var-aws_region=${__data.fields.aws_region}&var-dbidentifier=${__data.fields.dbidentifier}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Days remaining"
+                     },
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "red",
+                                 "value": 0
+                              },
+                              {
+                                 "color": "orange",
+                                 "value": 30
+                              },
+                              {
+                                 "color": "green",
+                                 "value": 90
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "d"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 11
+         },
+         "id": 12,
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "rds_standard_support_engine_remaining_days{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"} < 90\nand\nrds_standard_support_engine_remaining_days{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"} > 0\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Instances with standard support ending soon",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "__name__": true,
+                     "container": true,
+                     "context": true,
+                     "endpoint": true,
+                     "instance": true,
+                     "job": true,
+                     "kubernetes_cluster": true,
+                     "namespace": true,
+                     "pod": true,
+                     "prometheus": true,
+                     "service": true
+                  },
+                  "indexByName": {
+                     "Value": 3,
+                     "aws_account_id": 0,
+                     "aws_region": 1,
+                     "dbidentifier": 2,
+                     "engine": 4,
+                     "engine_version": 5
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "RDS instances running in extended support",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "displayMode": "color-text"
+               },
+               "decimals": 0,
+               "noValue": "No instance",
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "white",
+                        "value": 0
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "dbidentifier"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "",
+                              "url": "/d/a7049b32-6be3-42e5-aa9a-2879a14f46dd/?${datasource:queryparam}&${__url_time_range}&var-aws_account_id=${__data.fields.aws_account_id}&var-aws_region=${__data.fields.aws_region}&var-dbidentifier=${__data.fields.dbidentifier}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Days remaining"
+                     },
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "red",
+                                 "value": 0
+                              },
+                              {
+                                 "color": "orange",
+                                 "value": 30
+                              },
+                              {
+                                 "color": "green",
+                                 "value": 90
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "id": "unit",
+                        "value": "d"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 11
+         },
+         "id": 13,
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "rds_extended_support_engine_remaining_days{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}\nand on (aws_account_id, aws_region, dbidentifier)\n(\n  rds_standard_support_engine_remaining_days{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"} < 0\n)\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Instances with extended support",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "__name__": true,
+                     "container": true,
+                     "context": true,
+                     "endpoint": true,
+                     "instance": true,
+                     "job": true,
+                     "kubernetes_cluster": true,
+                     "namespace": true,
+                     "pod": true,
+                     "prometheus": true,
+                     "service": true
+                  },
+                  "indexByName": {
+                     "Value": 3,
+                     "aws_account_id": 0,
+                     "aws_region": 1,
+                     "dbidentifier": 2,
+                     "engine": 4,
+                     "engine_version": 5
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 0,
+            "x": 24,
+            "y": 16
+         },
+         "id": 14,
+         "title": "Inventory",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "List of RDS instances in selected AWS account(s) and region(s)",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "displayMode": "color-text"
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "white",
+                        "value": 0
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "dbidentifier"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "",
+                              "url": "/d/a7049b32-6be3-42e5-aa9a-2879a14f46dd/?${datasource:queryparam}&${__url_time_range}&var-aws_account_id=${__data.fields.aws_account_id}&var-aws_region=${__data.fields.aws_region}&var-dbidentifier=${__data.fields.dbidentifier}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "cluster_identifier"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "",
+                              "url": "/d/0197d764-40cc-7042-a4df-f2e3146275a6/?${datasource:queryparam}&${__url_time_range}&var-aws_account_id=${__data.fields.aws_account_id}&var-aws_region=${__data.fields.aws_region}&var-cluster_identifier=${__data.fields.cluster_identifier}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "multi_az"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "deletion_protection"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pending_modified_values"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "green",
+                                    "index": 0
+                                 },
+                                 "true": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "performance_insights_enabled"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "false": {
+                                    "color": "yellow",
+                                    "index": 1
+                                 },
+                                 "true": {
+                                    "color": "green",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pending_maintenance"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "auto-applied": {
+                                    "color": "orange",
+                                    "index": 0
+                                 },
+                                 "forced": {
+                                    "color": "red",
+                                    "index": 1
+                                 },
+                                 "no": {
+                                    "color": "green",
+                                    "index": 0
+                                 },
+                                 "pending": {
+                                    "color": "yellow",
+                                    "index": 0
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 17
+         },
+         "id": 15,
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"} * on (dbidentifier) group_left max(rds_allocated_storage_bytes{}) by (dbidentifier)\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "RDS instances",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value": false,
+                     "__name__": true,
+                     "container": true,
+                     "context": true,
+                     "endpoint": true,
+                     "environment": true,
+                     "instance": true,
+                     "job": true,
+                     "kubernetes_cluster": true,
+                     "namespace": true,
+                     "pod": true,
+                     "prometheus": true,
+                     "service": true
+                  },
+                  "indexByName": {
+                     "Time": 2,
+                     "Value": 19,
+                     "aws_account_id": 0,
+                     "aws_region": 1,
+                     "ca_certificate_identifier": 16,
+                     "cluster_identifier": 3,
+                     "dbi_resource_id": 18,
+                     "dbidentifier": 4,
+                     "deletion_protection": 12,
+                     "engine": 5,
+                     "engine_version": 7,
+                     "instance": 8,
+                     "instance_class": 9,
+                     "job": 10,
+                     "multi_az": 11,
+                     "pending_maintenance": 13,
+                     "pending_modified_values": 14,
+                     "performance_insights_enabled": 15,
+                     "role": 6,
+                     "storage_type": 17
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 0,
+            "x": 24,
+            "y": 24
+         },
+         "id": 16,
+         "title": "AWS Quota",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Ratio of used RDS instances regarding AWS quota",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineStyle": {
+                     "dash": [
+                        true
+                     ],
+                     "fill": "solid"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "line"
+                  }
+               },
+               "decimals": 0,
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "percentage",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "red",
+                        "value": 100
+                     }
+                  ]
+               },
+               "unit": "percent"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+         },
+         "id": 17,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "min",
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right"
+            }
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "count(\n    count(rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}) by (aws_account_id, aws_region, dbidentifier)\n) by (aws_account_id, aws_region)\n* 100\n/\nsum(\n    max(rds_quota_max_dbinstances_average{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}) by (aws_account_id, aws_region)\n) by (aws_account_id, aws_region)\n",
+               "legendFormat": "{{ aws_account_id }}:{{ aws_region }}"
+            }
+         ],
+         "title": "RDS instance quota usage (ratio)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "Ratio of used RDS storage regarding AWS quota",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineStyle": {
+                     "dash": [
+                        true
+                     ],
+                     "fill": "solid"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "line"
+                  }
+               },
+               "decimals": 0,
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "percentage",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "red",
+                        "value": 100
+                     }
+                  ]
+               },
+               "unit": "percent"
+            }
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 25
+         },
+         "id": 18,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "min",
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right"
+            }
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n    max(rds_allocated_storage_bytes{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}) by (aws_account_id, aws_region, dbidentifier)\n) by (aws_account_id, aws_region)\n* 100\n/\nsum(\n    max(rds_quota_total_storage_bytes{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}) by (aws_account_id, aws_region)\n) by (aws_account_id, aws_region)\n",
+               "legendFormat": "{{ aws_account_id }}:{{ aws_region }}"
+            }
+         ],
+         "title": "RDS storage quota usage (ratio)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "The number of instances regarding your RDS instances quota. You can request a quota increase to AWS",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "decimals": 0,
+               "min": 0
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "Max.*"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.fillOpacity",
+                        "value": 0
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "Total.*"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "green",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 33
+         },
+         "id": 19,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "min",
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right"
+            }
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n    max(rds_quota_max_dbinstances_average{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}) by (aws_account_id, aws_region)\n) by (aws_account_id, aws_region)\n",
+               "legendFormat": "Max {{ aws_account_id }}:{{ aws_region }}"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "count(\n    count(rds_instance_info{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}) by (aws_account_id, aws_region, dbidentifier)\n) by (aws_account_id, aws_region)\n",
+               "legendFormat": "Total {{ aws_account_id }}:{{ aws_region }}"
+            }
+         ],
+         "title": "RDS instance quota",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "The total storage used regarding your RDS total storage quota. You can request a quota increase to AWS",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10
+               },
+               "decimals": 0,
+               "min": 0,
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "Max.*"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.fillOpacity",
+                        "value": 0
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "Total.*"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "green",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 33
+         },
+         "id": 20,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "min",
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right"
+            }
+         },
+         "pluginVersion": "v10.2.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n    max(rds_quota_total_storage_bytes{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}) by (aws_account_id, aws_region)\n) by (aws_account_id, aws_region)\n",
+               "legendFormat": "Max {{ aws_account_id }}:{{ aws_region }}"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum(\n    max(rds_allocated_storage_bytes{aws_account_id=~\"$aws_account_id\",aws_region=~\"$aws_region\"}) by (aws_account_id, aws_region, dbidentifier)\n) by (aws_account_id, aws_region)\n",
+               "legendFormat": "Total {{ aws_account_id }}:{{ aws_region }}"
+            }
+         ],
+         "title": "RDS storage quota",
+         "type": "timeseries"
+      }
+   ],
+   "schemaVersion": 36,
+   "tags": [
+      "dmf",
+      "server"
+   ],
+   "templating": {
+      "list": [
+         {
+            "description": "Prometheus data source",
+            "label": "Data source",
+            "name": "datasource",
+            "query": "prometheus",
+            "type": "datasource"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "description": "AWS Account ID",
+            "includeAll": true,
+            "label": "Account",
+            "multi": true,
+            "name": "aws_account_id",
+            "query": "label_values(rds_instance_info, aws_account_id)",
+            "refresh": 2,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "description": "AWS region",
+            "includeAll": true,
+            "label": "Region",
+            "multi": true,
+            "name": "aws_region",
+            "query": "label_values(rds_instance_info{aws_account_id=~\"$aws_account_id\"}, aws_region)",
+            "refresh": 2,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-6h",
+      "to": "now"
+   },
+   "timezone": "utc",
+   "title": "RDS instances",
+   "uid": "f65d785e-d8c2-49b5-8314-388f30483f57"
+}

--- a/configs/grafana/queries/instance.libsonnet
+++ b/configs/grafana/queries/instance.libsonnet
@@ -139,15 +139,21 @@ local variables = import '../variables.libsonnet';
       usagePercent:
         prometheusQuery.new(
           '$' + variables.datasource.name,
-          '(\n' +
-          '  100 -(\n' +
-          '    rds_free_storage_bytes{aws_account_id="$aws_account_id", aws_region="$aws_region", dbidentifier="$dbidentifier"} * 100\n' +
-          '  ) / rds_allocated_storage_bytes{aws_account_id="$aws_account_id", aws_region="$aws_region", dbidentifier="$dbidentifier"}\n' +
-          ') or on(aws_account_id, aws_region, dbidentifier) (\n' +
-          '  max by (aws_account_id, aws_region, dbidentifier) (\n' +
-          '    rds_allocated_storage_bytes{aws_account_id="$aws_account_id", aws_region="$aws_region", dbidentifier="$dbidentifier"}\n' +
-          '  ) * 100 / (' + variables.aurora_storage_limits_bytes + ')\n' +
-          ')'
+          |||
+            (
+              100 - max by (aws_account_id, aws_region, dbidentifier) (
+                rds_free_storage_bytes{aws_account_id="$aws_account_id",aws_region="$aws_region",dbidentifier="$dbidentifier"}
+                * 100
+                / rds_allocated_storage_bytes{aws_account_id="$aws_account_id",aws_region="$aws_region",dbidentifier="$dbidentifier"}
+              )
+            ) or on(aws_account_id, aws_region, dbidentifier) (
+              max by (aws_account_id, aws_region, dbidentifier) (
+                rds_allocated_storage_bytes{aws_account_id="$aws_account_id",aws_region="$aws_region",dbidentifier="$dbidentifier"}
+              )
+              * 100
+              / 281474976710656
+            )
+          |||
         )
         + prometheusQuery.withLegendFormat('{{dbidentifier}}'),
     },


### PR DESCRIPTION
## Summary
- Wrap the first branch of the `usagePercent` PromQL query in `max by (aws_account_id, aws_region, dbidentifier)` to deduplicate series when multiple exporter pods scrape the same RDS instance
- Preserve the Aurora fallback (`or on(...)` second branch using 256 TiB max storage)
- Regenerate `rds-instances.json` which was empty on main (pre-existing build drift)

## Test plan
- [ ] Deploy to staging and verify the **Storage** gauge (panel 21) renders a single series per `dbidentifier`
- [ ] Verify the **Used storage** timeseries (panel 36) renders a single series per `dbidentifier`
- [ ] Confirm Aurora instances still show storage usage via the fallback branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)