### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,6 +64,7 @@ jobs:
       - name: Downgrade Helm  # 1.13.0 has bug that block push charts on OCI
         run: |
           curl -sSLo /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.12.0-linux-amd64.tar.gz" && \
+          echo "da36e117d6dbc57c8ec5bab2283222fbd108db86c83389eebe045ad1ef3e2c3b /tmp/helm.tar.gz" | sha256sum --check && \
           tar --strip-components=1 -C /tmp -xzvf /tmp/helm.tar.gz linux-amd64/helm && \
           mv /tmp/helm /usr/local/bin/helm && \
           rm -f /tmp/helm.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
         with:
           aws-region: us-east-1  # ECR Public can only be logged into from the us-east-1 region
           role-to-assume: arn:aws:iam::202662887508:role/ecr-prometheus-rds-exporter
@@ -28,20 +28,20 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419  # v2.1.5
         with:
           registry-type: public
 
       - run: git fetch --force --tags
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version: '1.24'
 
       - name: Set up QEMU for ARM64 build
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
 
-      - uses: goreleaser/goreleaser-action@v5
+      - uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811  # v5.1.0
         with:
           distribution: goreleaser
           version: latest
@@ -50,14 +50,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials for helm chart
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
         with:
           aws-region: us-east-1  # ECR Public can only be logged into from the us-east-1 region
           role-to-assume: arn:aws:iam::202662887508:role/ecr-prometheus-rds-exporter-chart
           role-session-name: githubActions
 
       - name: Login to Amazon ECR for helm chart
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419  # v2.1.5
         with:
           registry-type: public
 

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -13,13 +13,13 @@ jobs:
     name: golangci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version: '1.24'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84  # v6.5.2
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
@@ -55,7 +55,7 @@ jobs:
     name: yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Lint YAML files
         run: yamllint .  # YAML lint is already installed in ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,6 +70,7 @@ jobs:
       - name: Install kubeconform
         run: |
           curl -sSLo /tmp/kubeconform.tar.gz "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+          && echo "d2a10db6b78d56de8fe9375b9c351bc573aa218a74da04d114767b505a675090  /tmp/kubeconform.tar.gz" | sha256sum --check \
           && tar -C /usr/local/bin/ -xzvf /tmp/kubeconform.tar.gz
       - name: Run Kubeconform test
         run: make kubeconform

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,8 +16,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version: "1.22"
       - name: Install dependencies
@@ -28,7 +28,7 @@ jobs:
       - name: Run Go tests
         run: make test
       - name: Code Coverage Report
-        uses: irongut/CodeCoverageSummary@v1.3.0
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95  # v1.3.0
         with:
           filename: coverage.xml
           badge: true
@@ -39,10 +39,10 @@ jobs:
           indicators: true
           output: both
           thresholds: "60 80"
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653  # v1.3.5
         id: finder
       - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405  # v2.9.4
         with:
           number: ${{ github.event.pull_request.number }}
           path: code-coverage-results.md
@@ -54,7 +54,7 @@ jobs:
     env:
       HELM_UNITTEST_VERSION: v0.3.5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Install helm-unittest
         run: helm plugin install --version $HELM_UNITTEST_VERSION https://github.com/helm-unittest/helm-unittest.git
       - name: Run Helm test
@@ -66,7 +66,7 @@ jobs:
     env:
       KUBECONFORM_VERSION: 0.6.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Install kubeconform
         run: |
           curl -sSLo /tmp/kubeconform.tar.gz "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
@@ -78,18 +78,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
           go-version: '1.24'
 
       - name: Set up QEMU for ARM64 build
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
 
-      - uses: goreleaser/goreleaser-action@v5
+      - uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811  # v5.1.0
         with:
           distribution: goreleaser
           version: latest
@@ -107,17 +107,17 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Checkov GitHub Action
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@4048c972aae68d0b983a48bb3479aab2d877b898  # v12
         with:
           # This will add both a CLI output to the console and create a results.sarif file
           output_format: cli,sarif
           output_file_path: console,results.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3.35.4
 
         # Results are generated only on a success or failure
         # this is required since GitHub by default won't run the next step


### PR DESCRIPTION
# Goal

Harden GitHub Actions workflows against supply chain attacks by pinning all action references to immutable commit SHAs and adding integrity verification for downloaded binaries.

# Why

A security audit flagged multiple high-confidence findings across our CI/CD workflows:

- **Unpinned actions in high-privilege workflows** — All actions used mutable major-version tags (e.g., `@v4`, `@v5`) instead of pinned commit SHAs. In workflows with `contents: write`, `id-token: write`, `pull-requests: write`, or `security-events: write` permissions, a compromised upstream action could steal OIDC tokens, push malicious releases, exfiltrate code, or suppress security findings.
- **Binary downloads without integrity verification** — Helm and kubeconform binaries were downloaded and executed without checksum validation, leaving the pipeline vulnerable to CDN compromise or DNS hijacking.

These are well-known supply chain attack vectors (ref: [tj-actions/changed-files compromise, March 2025](https://blog.stepsecurity.io/tj-actions-changed-files-attack-analysis/)).

# How

### Pinned actions to full commit SHAs

All actions across 3 workflow files are now pinned to their latest patch-level commit SHA with a version comment for readability:

| Workflow | Actions pinned |
|----------|---------------|
| `build.yaml` | `actions/checkout`, `aws-actions/configure-aws-credentials`, `aws-actions/amazon-ecr-login`, `actions/setup-go`, `docker/setup-qemu-action`, `goreleaser/goreleaser-action` |
| `linter.yaml` | `actions/checkout`, `actions/setup-go`, `golangci/golangci-lint-action` |
| `test.yaml` | `actions/checkout`, `actions/setup-go`, `irongut/CodeCoverageSummary`, `jwalton/gh-find-current-pr`, `marocchino/sticky-pull-request-comment`, `docker/setup-qemu-action`, `goreleaser/goreleaser-action`, `bridgecrewio/checkov-action`, `github/codeql-action/upload-sarif` |

### Added SHA256 checksum verification for binary downloads

- **Helm v3.12.0** (`build.yaml`): verified against official release checksum `da36e117...`
- **kubeconform v0.6.2** (`test.yaml`): verified against official release checksum `d2a10db6...`

Both steps will now fail-fast if the downloaded binary doesn't match the expected hash.

# Release

No functional changes. Existing Dependabot configuration will automatically propose PRs when pinned SHAs have newer versions available.